### PR TITLE
Fix/improve-error-messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPersonToTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonToTableCommand.java
@@ -56,6 +56,10 @@ public class AddPersonToTableCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         try {
+            if (!model.hasCurrentWedding()) {
+                throw new CommandException("No current wedding set. Please use 'setWedding' first.");
+            }
+
             Person personToAdd = model.findPersonByName(guestName);
 
             model.addPersonToTableById(personToAdd, newTableId);

--- a/src/main/java/seedu/address/logic/commands/AddPersonToTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonToTableCommand.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.table.exceptions.TableFullException;
 import seedu.address.model.table.exceptions.TableNotFoundException;
 
@@ -55,23 +56,26 @@ public class AddPersonToTableCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        try {
-            if (!model.hasCurrentWedding()) {
-                throw new CommandException("No current wedding set. Please use 'setWedding' first.");
-            }
 
+        if (!model.hasCurrentWedding()) {
+            throw new CommandException("No current wedding set. Please use 'setWedding' first.");
+        }
+
+        try {
             Person personToAdd = model.findPersonByName(guestName);
 
             model.addPersonToTableById(personToAdd, newTableId);
 
             return new CommandResult(String.format(MESSAGE_ADD_GUEST_TO_TABLE_SUCCESS,
-                personToAdd.getName().fullName, newTableId));
+                    personToAdd.getName().fullName, newTableId));
+
+        } catch (PersonNotFoundException e) {
+            throw new CommandException(String.format("Person '%s' not found in the guest list.", guestName.fullName));
         } catch (TableNotFoundException e) {
             throw new CommandException(String.format(MESSAGE_TABLE_NOT_FOUND, newTableId));
         } catch (TableFullException e) {
             throw new CommandException(String.format(MESSAGE_TABLE_FULL, newTableId));
         }
-
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTableCommand.java
@@ -36,23 +36,6 @@ public class AddTableCommand extends Command {
         this.capacity = capacity;
     }
 
-    // @Override
-    // public CommandResult execute(Model model) throws CommandException {
-    //     requireNonNull(model);
-    //
-    //     try {
-    //         Table t = model.getTableById(tableId);
-    //         throw new CommandException(MESSAGE_DUPLICATE_TABLE);
-    //
-    //     } catch (TableNotFoundException tnfe) {
-    //
-    //         Table table = new Table(tableId, capacity);
-    //         model.addTable(table);
-    //
-    //         return new CommandResult(String.format(MESSAGE_SUCCESS, tableId, capacity));
-    //     }
-    //
-    // }
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/AddTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTableCommand.java
@@ -14,7 +14,6 @@ public class AddTableCommand extends Command {
     public static final String COMMAND_WORD = "addTable";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a table to the current wedding.\n"
-            + "Precondition: A wedding must be set before using this command.\n"
             + "Parameters: tid/TABLE_ID c/CAPACITY\n"
             + "Example: " + COMMAND_WORD + " tid/1 c/6";
 

--- a/src/main/java/seedu/address/logic/commands/AddTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTableCommand.java
@@ -13,14 +13,17 @@ public class AddTableCommand extends Command {
 
     public static final String COMMAND_WORD = "addTable";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a table to the wedding.\n"
-            + "Parameters: TABLE_ID CAPACITY\n"
-            + "Example: " + COMMAND_WORD + "tid/1 capacity/6";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a table to the current wedding.\n"
+            + "Precondition: A wedding must be set before using this command.\n"
+            + "Parameters: tid/TABLE_ID c/CAPACITY\n"
+            + "Example: " + COMMAND_WORD + " tid/1 c/6";
 
     public static final String MESSAGE_SUCCESS = "Table added: Table ID: %1$d, Capacity: %2$d";
-    public static final String MESSAGE_NO_CURRENT_WEDDING =
-        "No current wedding set. Use setWedding command first.";
-    public static final String MESSAGE_DUPLICATE_TABLE = "A table with this ID already exists.";
+    public static final String MESSAGE_NO_CURRENT_WEDDING = "You must set a wedding before adding tables. "
+            + "Please use the setWedding command.";
+    public static final String MESSAGE_DUPLICATE_TABLE = "A table with ID %1$d already exists. "
+            + "Please choose a different ID.";
+    public static final String MESSAGE_INVALID_TABLE = "Invalid table configuration: %s";
 
     private final int tableId;
     private final int capacity;
@@ -39,21 +42,29 @@ public class AddTableCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        // Check if there's a current wedding
+
         if (model.getCurrentWedding() == null) {
             throw new CommandException(MESSAGE_NO_CURRENT_WEDDING);
         }
-        // Check for duplicate table ID
+
         if (model.hasTable(tableId)) {
-            throw new CommandException(MESSAGE_DUPLICATE_TABLE);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_TABLE, tableId));
         }
+
         try {
             Table table = new Table(tableId, capacity);
             model.addTable(table);
             return new CommandResult(String.format(MESSAGE_SUCCESS, tableId, capacity));
         } catch (IllegalArgumentException e) {
-            throw new CommandException("Invalid table: " + e.getMessage());
+            throw new CommandException(String.format(MESSAGE_INVALID_TABLE, e.getMessage()));
         }
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof AddTableCommand
+                && tableId == ((AddTableCommand) other).tableId
+                && capacity == ((AddTableCommand) other).capacity);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
@@ -28,8 +28,6 @@ public class DeletePersonFromTableCommand extends Command {
         + PREFIX_TABLE_ID + "2";
 
     public static final String MESSAGE_REMOVED_GUEST_FROM_TABLE_SUCCESS = "Deleted Person: %s from Table: %d";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This guest already exists in the address book.";
 
     private final Name guestName;
     private final int oldTableId;

--- a/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
@@ -9,6 +9,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.table.Table;
 
 /**
  * Deletes a guest from the given table.
@@ -48,17 +50,45 @@ public class DeletePersonFromTableCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        // 1. Check if wedding is set
         if (!model.hasCurrentWedding()) {
             throw new CommandException("No current wedding set. Please use 'setWedding' first.");
         }
 
-        Person guestToRemove = model.findPersonByName(guestName);
+        // 2. Try to find the person by name, catch if not found
+        Person guestToRemove;
+        try {
+            guestToRemove = model.findPersonByName(guestName);
+        } catch (seedu.address.model.person.exceptions.PersonNotFoundException e) {
+            throw new CommandException(String.format("Person '%s' not found in the guest list.", guestName.fullName));
+        }
 
+        // 3. Check if the table exists
+        if (!model.hasTable(oldTableId)) {
+            throw new CommandException(String.format("Table with ID %d does not exist.", oldTableId));
+        }
+
+        Table table = model.getCurrentWedding().findTableById(oldTableId);
+        if (table == null) {
+            throw new CommandException(String.format("Table with ID %d could not be found.", oldTableId));
+        }
+
+        // 4. Check if the person is assigned to the table
+        try {
+            table.findPerson(guestToRemove); // throws if not assigned
+        } catch (PersonNotFoundException e) {
+            throw new CommandException(String.format("Person '%s' is not assigned to Table %d.",
+                    guestName.fullName, oldTableId));
+        }
+
+        // 5. Safe to delete
         model.deletePersonFromTableById(guestToRemove, oldTableId);
 
         return new CommandResult(String.format(MESSAGE_REMOVED_GUEST_FROM_TABLE_SUCCESS,
-            guestToRemove.getName().fullName, oldTableId));
+                guestToRemove.getName().fullName, oldTableId));
     }
+
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonFromTableCommand.java
@@ -48,6 +48,10 @@ public class DeletePersonFromTableCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        if (!model.hasCurrentWedding()) {
+            throw new CommandException("No current wedding set. Please use 'setWedding' first.");
+        }
+
         Person guestToRemove = model.findPersonByName(guestName);
 
         model.deletePersonFromTableById(guestToRemove, oldTableId);

--- a/src/main/java/seedu/address/logic/commands/DeleteTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTableCommand.java
@@ -24,6 +24,11 @@ public class DeleteTableCommand extends Command {
 
     private final int tableId;
 
+    /**
+     * Creates a DeleteTableCommand to delete the table with the given ID.
+     *
+     * @param tableId ID of the table to delete
+     */
     public DeleteTableCommand(int tableId) {
         this.tableId = tableId;
     }
@@ -39,7 +44,6 @@ public class DeleteTableCommand extends Command {
         if (tableId <= 0) {
             throw new CommandException(MESSAGE_INVALID_TABLE_ID);
         }
-
 
         try {
             model.deleteTableById(tableId);

--- a/src/main/java/seedu/address/logic/commands/DeleteTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTableCommand.java
@@ -13,8 +13,8 @@ public class DeleteTableCommand extends Command {
     public static final String COMMAND_WORD = "deleteTable";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a table from the current wedding.\n"
-            + "Parameters: tableId/TABLE_ID or just the ID\n"
-            + "Example: " + COMMAND_WORD + " tableId/1 or " + COMMAND_WORD + " 1";
+            + "Parameters: tid/TABLE_ID or just the ID\n"
+            + "Example: " + COMMAND_WORD + " tid/1 or 1";
 
     public static final String MESSAGE_SUCCESS = "Table deleted: Table ID %d";
     public static final String MESSAGE_NO_CURRENT_WEDDING =

--- a/src/main/java/seedu/address/logic/commands/FindTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTableCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.table.Table;
+import seedu.address.model.table.exceptions.TableNotFoundException;
 
 /**
  * Finds and displays a table by its ID.
@@ -13,9 +14,12 @@ public class FindTableCommand extends Command {
 
     public static final String COMMAND_WORD = "findTable";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds a table by its ID in the current wedding.\n"
-            + "Parameters: tableId/TABLE_ID\n"
-            + "Example: " + COMMAND_WORD + " tableId/1";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds a table by its ID in the current wedding.\n"
+            + "Parameters: [tableId/TABLE_ID] or just the TABLE_ID\n"
+            + "Examples: \n"
+            + "  " + COMMAND_WORD + " tableId/1\n"
+            + "  " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_NO_CURRENT_WEDDING = "No current wedding set. Use createWedding command first.";
     public static final String MESSAGE_TABLE_NOT_FOUND = "Table with ID %d not found.";
@@ -42,15 +46,24 @@ public class FindTableCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        Table table = model.findTableById(tableId);
-
-        if (table == null) {
-            throw new CommandException(String.format(MESSAGE_TABLE_NOT_FOUND, tableId));
+        if (!model.hasCurrentWedding()) {
+            throw new CommandException(MESSAGE_NO_CURRENT_WEDDING);
         }
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS,
-                table.getTableId(), table.getCapacity(), table.getAllPersons().size()));
+        try {
+            Table table = model.findTableById(tableId);
+
+            return new CommandResult(String.format(
+                    MESSAGE_SUCCESS,
+                    table.getTableId(),
+                    table.getCapacity(),
+                    table.getAllPersons().size()));
+        } catch (TableNotFoundException e) {
+            throw new CommandException(String.format(MESSAGE_TABLE_NOT_FOUND, tableId));
+        }
     }
+
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/FindTableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTableCommand.java
@@ -16,12 +16,12 @@ public class FindTableCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds a table by its ID in the current wedding.\n"
-            + "Parameters: [tableId/TABLE_ID] or just the TABLE_ID\n"
+            + "Parameters: [tid/TABLE_ID] \n"
             + "Examples: \n"
-            + "  " + COMMAND_WORD + " tableId/1\n"
-            + "  " + COMMAND_WORD + " 1";
+            + "  " + COMMAND_WORD + " tid/1\n";
 
-    public static final String MESSAGE_NO_CURRENT_WEDDING = "No current wedding set. Use createWedding command first.";
+
+    public static final String MESSAGE_NO_CURRENT_WEDDING = "No current wedding set. Use setWedding command first.";
     public static final String MESSAGE_TABLE_NOT_FOUND = "Table with ID %d not found.";
     public static final String MESSAGE_SUCCESS = "Table found: Table ID: %d | Capacity: %d | Guests: %d";
 

--- a/src/main/java/seedu/address/logic/commands/GetAllTablesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GetAllTablesCommand.java
@@ -18,7 +18,7 @@ public class GetAllTablesCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all tables in the current wedding.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_NO_CURRENT_WEDDING = "No current wedding set. Use createWedding command first.";
+    public static final String MESSAGE_NO_CURRENT_WEDDING = "No current wedding set. Use setWedding command first.";
     public static final String MESSAGE_NO_TABLES = "No tables found for this wedding.";
     public static final String MESSAGE_SUCCESS = "List of tables:\n%1$s";
 

--- a/src/main/java/seedu/address/logic/commands/WeddingOverviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/WeddingOverviewCommand.java
@@ -49,7 +49,7 @@ public class WeddingOverviewCommand extends Command {
         List<Person> guests = model.getFilteredPersonList();
         int guestCount = guests.size();
 
-        // ✅ Format the guest list properly
+
         StringBuilder guestListFormatted = new StringBuilder();
         if (guests.isEmpty()) {
             guestListFormatted.append("No guests added yet.");

--- a/src/main/java/seedu/address/logic/parser/AddTableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTableCommandParser.java
@@ -4,78 +4,37 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CAPACITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TABLE_ID;
 
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.AddTableCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses user input and creates an AddTableCommand object.
+ * Parses input arguments and creates a new AddTableCommand object.
  */
 public class AddTableCommandParser implements Parser<AddTableCommand> {
 
-    /**
-     * Parses the given {@code String} of arguments in the context of the AddTableCommand
-     * and returns an AddTableCommand object for execution.
-     *
-     * @param args The input string containing the arguments.
-     * @return An AddTableCommand object with parsed arguments.
-     * @throws ParseException if the input is invalid.
-     */
+    @Override
     public AddTableCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TABLE_ID, PREFIX_CAPACITY);
 
-        if (argMultimap.getValue(PREFIX_TABLE_ID).isPresent()
-                && argMultimap.getValue(PREFIX_CAPACITY).isPresent()) {
-
-            int tableId = parseInteger(argMultimap, PREFIX_TABLE_ID, "Table ID");
-            int capacity = parseInteger(argMultimap, PREFIX_CAPACITY, "Capacity");
-            return new AddTableCommand(tableId, capacity);
+        if (!arePrefixesPresent(argMultimap, PREFIX_TABLE_ID, PREFIX_CAPACITY)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddTableCommand.MESSAGE_USAGE));
         }
 
-        // fallback: try positional input like: addTable 3 5
-        String[] tokens = args.trim().split("\\s+");
-        if (tokens.length != 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE));
-        }
+        int tableId = ParserUtil.parseTableId(argMultimap.getValue(PREFIX_TABLE_ID).get());
+        int capacity = ParserUtil.parseCapacity(argMultimap.getValue(PREFIX_CAPACITY).get());
 
-        try {
-            int tableId = Integer.parseInt(tokens[0]);
-            int capacity = Integer.parseInt(tokens[1]);
-            return new AddTableCommand(tableId, capacity);
-        } catch (NumberFormatException e) {
-            throw new ParseException("Table ID and capacity must be valid integers.");
-        }
+        return new AddTableCommand(tableId, capacity);
     }
 
-
     /**
-     * Parses an integer value from the argument multimap.
-     *
-     * @param argMultimap The argument multimap containing user input.
-     * @param prefix The prefix associated with the value.
-     * @param fieldName The name of the field (for error messages).
-     * @return The parsed integer value.
-     * @throws ParseException if the value is missing or not a valid integer.
+     * Returns true if all prefixes are present.
      */
-    // private int parseInteger(ArgumentMultimap argMultimap, Prefix prefix, String fieldName) throws ParseException {
-    //     if (!argMultimap.getValue(prefix).isPresent()) {
-    //         throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE));
-    //     }
-    //     try {
-    //         return Integer.parseInt(argMultimap.getValue(prefix).get());
-    //     } catch (NumberFormatException e) {
-    //         throw new ParseException(fieldName + " must be a valid integer.");
-    //     }
-    // }
-
-    private int parseInteger(ArgumentMultimap argMultimap, Prefix prefix, String fieldName) throws ParseException {
-        if (!argMultimap.getValue(prefix).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE));
-        }
-        try {
-            return Integer.parseInt(argMultimap.getValue(prefix).get());
-        } catch (NumberFormatException e) {
-            throw new ParseException(fieldName + " must be a valid integer.");
-        }
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,5 +14,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_DIETARY_RESTRICTION = new Prefix("d/");
     public static final Prefix PREFIX_RSVP = new Prefix("r/");
     public static final Prefix PREFIX_TABLE_ID = new Prefix("tid/");
-    public static final Prefix PREFIX_CAPACITY = new Prefix("capacity/");
+    public static final Prefix PREFIX_CAPACITY = new Prefix("c/");
+
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteTableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTableCommandParser.java
@@ -18,12 +18,12 @@ public class DeleteTableCommandParser implements Parser<DeleteTableCommand> {
     public DeleteTableCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TABLE_ID);
 
-        // ✅ Handle prefixed format: deleteTable tableId/2
+        // Handle prefixed format: deleteTable tableId/2
         if (argMultimap.getValue(PREFIX_TABLE_ID).isPresent()) {
             return parseWithPrefix(argMultimap);
         }
 
-        // ✅ Handle raw format: deleteTable 2
+        // Handle raw format: deleteTable 2
         String[] tokens = args.trim().split("\\s+");
 
         if (tokens.length != 1) {

--- a/src/main/java/seedu/address/logic/parser/FindTableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTableCommandParser.java
@@ -12,22 +12,37 @@ public class FindTableCommandParser implements Parser<FindTableCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of FindTableCommand.
-     * @throws ParseException if the input is invalid.
+     *
+     * @param args the user input after the command word
+     * @return FindTableCommand with parsed tableId
+     * @throws ParseException if the input is invalid
      */
     @Override
     public FindTableCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim().toLowerCase();
 
-        // Validate input (must have a number)
-        if (trimmedArgs.isEmpty() || !trimmedArgs.startsWith("tableid/")) {
+        if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTableCommand.MESSAGE_USAGE));
         }
 
+        String tableIdStr;
+
+        if (trimmedArgs.startsWith("tableid/")) {
+            tableIdStr = trimmedArgs.substring("tableid/".length()).trim();
+        } else {
+            tableIdStr = trimmedArgs;
+        }
+
         try {
-            int tableId = Integer.parseInt(trimmedArgs.split("/")[1]); // Extract table ID
+            int tableId = Integer.parseInt(tableIdStr);
+
+            if (tableId <= 0) {
+                throw new ParseException("Table ID must be a positive number.");
+            }
+
             return new FindTableCommand(tableId);
         } catch (NumberFormatException e) {
-            throw new ParseException("Invalid table ID. It must be a number.");
+            throw new ParseException("Invalid table ID. It must be a numeric value.");
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindTableCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTableCommandParser.java
@@ -10,28 +10,22 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class FindTableCommandParser implements Parser<FindTableCommand> {
 
-    /**
-     * Parses the given {@code String} of arguments in the context of FindTableCommand.
-     *
-     * @param args the user input after the command word
-     * @return FindTableCommand with parsed tableId
-     * @throws ParseException if the input is invalid
-     */
+    private static final String PREFIX_TID = "tid/";
+
     @Override
     public FindTableCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim().toLowerCase();
+        String trimmedArgs = args.trim();
 
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTableCommand.MESSAGE_USAGE));
         }
 
-        String tableIdStr;
-
-        if (trimmedArgs.startsWith("tableid/")) {
-            tableIdStr = trimmedArgs.substring("tableid/".length()).trim();
-        } else {
-            tableIdStr = trimmedArgs;
+        // Force strict format: must start with "tid/" (case insensitive)
+        if (!trimmedArgs.toLowerCase().startsWith(PREFIX_TID)) {
+            throw new ParseException("Invalid format. You must use the prefix 'tid/'. Example: findTable tid/3");
         }
+
+        String tableIdStr = trimmedArgs.substring(PREFIX_TID.length()).trim();
 
         try {
             int tableId = Integer.parseInt(tableIdStr);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -15,7 +15,6 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rsvp;
-import seedu.address.model.table.Table;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -172,12 +171,15 @@ public class ParserUtil {
      * @throws ParseException
      */
     public static int parseTableId(String tableId) throws ParseException {
-        String trimmedTableId = tableId.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedTableId)) {
-            throw new ParseException(Table.ID_CONSTRAINTS);
+        try {
+            int id = Integer.parseInt(tableId.trim());
+            if (id <= 0) {
+                throw new ParseException("Table ID must be a positive integer.");
+            }
+            return id;
+        } catch (NumberFormatException e) {
+            throw new ParseException("Invalid table ID. Must be an integer.");
         }
-
-        return Integer.parseInt(trimmedTableId);
     }
 
     /**
@@ -193,4 +195,24 @@ public class ParserUtil {
 
         return trimmedWeddingName;
     }
+
+    /**
+     * Parses a string into a positive integer representing table capacity.
+     *
+     * @param capStr The string containing the capacity to be parsed.
+     * @return The parsed capacity as a positive integer.
+     * @throws ParseException If the string is not a valid integer or the value is not positive.
+     */
+    public static int parseCapacity(String capStr) throws ParseException {
+        try {
+            int cap = Integer.parseInt(capStr.trim());
+            if (cap <= 0) {
+                throw new ParseException("Capacity must be a positive integer.");
+            }
+            return cap;
+        } catch (NumberFormatException e) {
+            throw new ParseException("Invalid capacity. Must be an integer.");
+        }
+    }
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -112,6 +112,7 @@ public interface Model {
 
     void deletePersonFromTable(Person p, Table table);
 
+
     void deletePersonFromTableById(Person p, int tableId);
 
     void setTable(Table target, Table editedTable);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -234,6 +234,7 @@ public class ModelManager implements Model {
         addressBook.addWedding(wedding);
     }
 
+
     @Override
     public void deleteCurrentWedding() {
         addressBook.deleteCurrentWedding();

--- a/src/test/java/seedu/address/logic/commands/AddTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTableCommandTest.java
@@ -68,7 +68,7 @@ public class AddTableCommandTest {
         AddTableCommand command = new AddTableCommand(3, -1); // invalid capacity
 
         CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
-        
+
         assertEquals("Invalid table configuration: "
                 + "The table capacity should be a positive integer", exception.getMessage());
     }

--- a/src/test/java/seedu/address/logic/commands/AddTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTableCommandTest.java
@@ -12,9 +12,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.table.Table;
 import seedu.address.model.wedding.Wedding;
 
-/**
- * Unit tests for AddTableCommand.
- */
 public class AddTableCommandTest {
 
     private Model model;
@@ -26,51 +23,49 @@ public class AddTableCommandTest {
 
     @Test
     public void execute_noWeddingSet_throwsCommandException() {
-        AddTableCommand command = new AddTableCommand(1, 5);
-
+        AddTableCommand command = new AddTableCommand(1, 6);
         CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
         assertEquals(AddTableCommand.MESSAGE_NO_CURRENT_WEDDING, exception.getMessage());
     }
 
     @Test
-    public void execute_duplicateTableId_throwsCommandException() throws CommandException {
+    public void execute_duplicateTableId_throwsCommandException() throws Exception {
         Wedding wedding = new Wedding("Test Wedding");
         model.addWedding(wedding);
         model.setCurrentWedding(wedding);
 
-        // Add table manually
-        model.addTable(new Table(1, 4));
+        model.addTable(new Table(1, 6)); // add initial table
 
-        AddTableCommand command = new AddTableCommand(1, 6); // duplicate tableId
+        AddTableCommand command = new AddTableCommand(1, 8); // duplicate ID
 
         CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
         assertEquals(String.format(AddTableCommand.MESSAGE_DUPLICATE_TABLE, 1), exception.getMessage());
     }
 
     @Test
-    public void execute_validInput_addsTableSuccessfully() throws Exception {
+    public void execute_invalidCapacity_throwsCommandException() throws Exception {
         Wedding wedding = new Wedding("Test Wedding");
         model.addWedding(wedding);
         model.setCurrentWedding(wedding);
 
-        AddTableCommand command = new AddTableCommand(2, 8);
+        AddTableCommand command = new AddTableCommand(2, -5); // invalid capacity
 
-        CommandResult result = command.execute(model);
-        assertEquals(String.format(AddTableCommand.MESSAGE_SUCCESS, 2, 8), result.getFeedbackToUser());
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("Invalid table configuration: The table capacity should be a positive integer",
+                exception.getMessage());
     }
 
     @Test
-    public void execute_invalidTable_throwsCommandException() {
-        Wedding wedding = new Wedding("Test Wedding");
+    public void execute_validInput_addsTableSuccessfully() throws Exception {
+        Wedding wedding = new Wedding("Valid Wedding");
         model.addWedding(wedding);
         model.setCurrentWedding(wedding);
 
-        AddTableCommand command = new AddTableCommand(3, -1); // invalid capacity
+        AddTableCommand command = new AddTableCommand(3, 10);
 
-        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        CommandResult result = command.execute(model);
 
-        assertEquals("Invalid table configuration: "
-                + "The table capacity should be a positive integer", exception.getMessage());
+        assertEquals(String.format(AddTableCommand.MESSAGE_SUCCESS, 3, 10), result.getFeedbackToUser());
     }
 
     @Test
@@ -88,4 +83,63 @@ public class AddTableCommandTest {
         assert (!cmd1.equals(cmd2));
         assert (!cmd1.equals(cmd3));
     }
+
+    @Test
+    public void execute_tableIdZero_throwsCommandException() throws Exception {
+        Wedding wedding = new Wedding("Zero ID Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        AddTableCommand command = new AddTableCommand(0, 6);
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("Invalid table configuration: The table ID should be a positive integer",
+                exception.getMessage());
+    }
+
+    @Test
+    public void execute_negativeTableId_throwsCommandException() throws Exception {
+        Wedding wedding = new Wedding("Negative ID Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        AddTableCommand command = new AddTableCommand(-2, 6);
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("Invalid table configuration: The table ID should be a positive integer",
+                exception.getMessage());
+    }
+
+    @Test
+    public void execute_zeroCapacity_throwsCommandException() throws Exception {
+        Wedding wedding = new Wedding("Zero Capacity Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        AddTableCommand command = new AddTableCommand(4, 0);
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("Invalid table configuration: The table capacity should be a positive integer",
+                exception.getMessage());
+    }
+
+    // @Test
+    // public void execute_maxIntegerCapacity_addsTableSuccessfully() throws Exception {
+    //     Wedding wedding = new Wedding("Big Wedding");
+    //     model.addWedding(wedding);
+    //     model.setCurrentWedding(wedding);
+    //
+    //     AddTableCommand command = new AddTableCommand(99, Integer.MAX_VALUE);
+    //     CommandResult result = command.execute(model);
+    //     assertEquals(String.format(AddTableCommand.MESSAGE_SUCCESS, 99, Integer.MAX_VALUE),
+    //     result.getFeedbackToUser());
+    // }
+
+    // @Test
+    // public void execute_tableIdOne_valid_success() throws Exception {
+    //     Wedding wedding = new Wedding("Boundary Test Wedding");
+    //     model.addWedding(wedding);
+    //     model.setCurrentWedding(wedding);
+    //
+    //     AddTableCommand command = new AddTableCommand(1, 5);
+    //     CommandResult result = command.execute(model);
+    //     assertEquals(String.format(AddTableCommand.MESSAGE_SUCCESS, 1, 5), result.getFeedbackToUser());
+    // }
 }

--- a/src/test/java/seedu/address/logic/commands/DeletePersonFromTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePersonFromTableCommandTest.java
@@ -22,8 +22,10 @@ import seedu.address.model.table.Table;
 import seedu.address.model.wedding.Wedding;
 
 public class DeletePersonFromTableCommandTest {
+
     private Model model;
     private Name name = new Name("John Doe");
+    private Person guest;
 
     @BeforeEach
     public void setUp() {
@@ -31,39 +33,80 @@ public class DeletePersonFromTableCommandTest {
         Wedding currentWedding = new Wedding("John and Jane's Wedding");
         model.addWedding(currentWedding);
         model.setCurrentWeddingByName("John and Jane's Wedding");
-        Table table = new Table(1, 10);
-        model.addTable(table);
+        model.addTable(new Table(1, 10));
+        model.addTable(new Table(2, 10));
 
-        Person guest = new Person(name,
-            new Phone("12345678"),
-            new Email("johndoe@example.com"),
-            new Address("123 Street"),
-            new HashSet<>(),
-            new DietaryRestriction(DietaryRestriction.TypicalRestriction.NONE),
-            new Rsvp(Rsvp.Status.YES),
-            -1);
+        guest = new Person(name,
+                new Phone("12345678"),
+                new Email("johndoe@example.com"),
+                new Address("123 Street"),
+                new HashSet<>(),
+                new DietaryRestriction(DietaryRestriction.TypicalRestriction.NONE),
+                new Rsvp(Rsvp.Status.YES),
+                -1);
 
         model.addPerson(guest);
         model.addPersonToTableById(guest, 1);
     }
 
     @Test
-    public void execute_deleteGuestFromTable_success() throws Exception {
-
+    public void execute_validGuestAtTable_success() throws Exception {
         DeletePersonFromTableCommand command = new DeletePersonFromTableCommand(name, 1);
-
         CommandResult result = command.execute(model);
 
-        boolean k = true;
         assertEquals(String.format(DeletePersonFromTableCommand.MESSAGE_REMOVED_GUEST_FROM_TABLE_SUCCESS,
-                name.fullName, 1),
-            result.getFeedbackToUser());
+                name.fullName, 1), result.getFeedbackToUser());
     }
 
     @Test
-    public void execute_deleteGuestFromTable_failure() {
-        AddPersonToTableCommand command = new AddPersonToTableCommand(name, 3);
+    public void execute_guestNotAtTable_throwsCommandException() throws Exception {
+        DeletePersonFromTableCommand command = new DeletePersonFromTableCommand(name, 2);
+        CommandException ex = assertThrows(CommandException.class, () -> command.execute(model));
 
-        assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("Person 'John Doe' is not assigned to Table 2.", ex.getMessage());
+    }
+
+    @Test
+    public void execute_tableDoesNotExist_throwsCommandException() {
+        DeletePersonFromTableCommand command = new DeletePersonFromTableCommand(name, 999);
+        CommandException ex = assertThrows(CommandException.class, () -> command.execute(model));
+
+        assertEquals("Table with ID 999 does not exist.", ex.getMessage());
+    }
+
+    @Test
+    public void execute_guestDoesNotExistInGuestList_throwsCommandException() {
+        Name ghost = new Name("Ghost");
+        DeletePersonFromTableCommand command = new DeletePersonFromTableCommand(ghost, 1);
+        CommandException ex = assertThrows(CommandException.class, () -> command.execute(model));
+
+        assertEquals("Person 'Ghost' not found in the guest list.", ex.getMessage());
+    }
+
+    @Test
+    public void execute_noCurrentWeddingSet_throwsCommandException() throws Exception {
+        // Reinitialize model with no wedding
+        model = new ModelManager();
+        DeletePersonFromTableCommand command = new DeletePersonFromTableCommand(name, 1);
+
+        CommandException ex = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals("No current wedding set. Please use 'setWedding' first.", ex.getMessage());
+    }
+
+    @Test
+    public void equals_sameValues_returnsTrue() {
+        DeletePersonFromTableCommand cmd1 = new DeletePersonFromTableCommand(name, 1);
+        DeletePersonFromTableCommand cmd2 = new DeletePersonFromTableCommand(name, 1);
+        assertEquals(cmd1, cmd2);
+    }
+
+    @Test
+    public void equals_differentValues_returnsFalse() {
+        DeletePersonFromTableCommand cmd1 = new DeletePersonFromTableCommand(name, 1);
+        DeletePersonFromTableCommand cmd2 = new DeletePersonFromTableCommand(new Name("Jane Doe"), 1);
+        DeletePersonFromTableCommand cmd3 = new DeletePersonFromTableCommand(name, 2);
+
+        assert (!cmd1.equals(cmd2));
+        assert (!cmd1.equals(cmd3));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTableCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -8,50 +9,79 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.table.Table;
 import seedu.address.model.wedding.Wedding;
 
-
 /**
- * Unit tests for {@link DeleteTableCommand}.
+ * Unit tests for DeleteTableCommand.
  */
 public class DeleteTableCommandTest {
+
     private Model model;
 
     @BeforeEach
     public void setUp() {
         model = new ModelManager();
-        model.addWedding(new Wedding("Test Wedding"));
-        model.setCurrentWeddingByName("Test Wedding");
-    }
-    // @Test
-    // public void execute_validTable_deletionSuccessful() throws CommandException {
-    //     // Add Debugging
-    //     Wedding wedding = model.getCurrentWedding();
-    //     model.addTable(new Table(1, 8));
-    //
-    //     DeleteTableCommand command = new DeleteTableCommand(1);
-    //     CommandResult result = command.execute(model);
-    //
-    //     String expectedMessage = "Table deleted: 1";
-    //     assertEquals(expectedMessage, result.getFeedbackToUser());
-    //
-    //     // Ensure the table was deleted
-    //     assertEquals(0, model.getCurrentWedding().getTableList().size());
-    // }
-
-    @Test
-    public void execute_nonExistentTable_throwsCommandException() {
-        DeleteTableCommand command = new DeleteTableCommand(5);
-        assertThrows(CommandException.class, () -> command.execute(model),
-                "Table with ID 5 not found.");
     }
 
     @Test
-    public void execute_noCurrentWedding_throwsCommandException() {
-        model = new ModelManager(); // ✅ Create a fresh ModelManager with NO wedding
-        DeleteTableCommand command = new DeleteTableCommand(2);
-        // Expect a CommandException with "No current wedding set. Use setWedding command first."
-        assertThrows(CommandException.class, () -> command.execute(model),
-                "No current wedding set. Use setWedding command first.");
+    public void execute_noWeddingSet_throwsCommandException() {
+        DeleteTableCommand command = new DeleteTableCommand(1);
+
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals(DeleteTableCommand.MESSAGE_NO_CURRENT_WEDDING, exception.getMessage());
+    }
+
+    @Test
+    public void execute_invalidTableId_throwsCommandException() {
+        Wedding wedding = new Wedding("Test Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        DeleteTableCommand command = new DeleteTableCommand(-2); // invalid table ID
+
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals(DeleteTableCommand.MESSAGE_INVALID_TABLE_ID, exception.getMessage());
+    }
+
+    @Test
+    public void execute_tableNotFound_throwsCommandException() {
+        Wedding wedding = new Wedding("Test Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        DeleteTableCommand command = new DeleteTableCommand(10); // table not added
+
+        CommandException exception = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals(String.format(DeleteTableCommand.MESSAGE_TABLE_NOT_FOUND, 10), exception.getMessage());
+    }
+
+    @Test
+    public void execute_validTableId_deletesSuccessfully() throws Exception {
+        Wedding wedding = new Wedding("Test Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        Table table = new Table(1, 5);
+        model.addTable(table);
+
+        DeleteTableCommand command = new DeleteTableCommand(1);
+        CommandResult result = command.execute(model);
+
+        assertEquals(String.format(DeleteTableCommand.MESSAGE_SUCCESS, 1), result.getFeedbackToUser());
+    }
+
+    @Test
+    public void equals_sameValues_returnsTrue() {
+        DeleteTableCommand cmd1 = new DeleteTableCommand(1);
+        DeleteTableCommand cmd2 = new DeleteTableCommand(1);
+        assertEquals(cmd1, cmd2);
+    }
+
+    @Test
+    public void equals_differentValues_returnsFalse() {
+        DeleteTableCommand cmd1 = new DeleteTableCommand(1);
+        DeleteTableCommand cmd2 = new DeleteTableCommand(2);
+        assert (!cmd1.equals(cmd2));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTableCommandTest.java
@@ -1,4 +1,89 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.DietaryRestriction;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Rsvp;
+import seedu.address.model.table.Table;
+import seedu.address.model.wedding.Wedding;
+
 public class FindTableCommandTest {
+
+    private Model model;
+    private final Table testTable = new Table(3, 5);
+    private final Name guestName = new Name("Guest A");
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager();
+        Wedding wedding = new Wedding("Test Wedding");
+        model.addWedding(wedding);
+        model.setCurrentWedding(wedding);
+
+        model.addTable(testTable);
+
+        Person guest = new Person(guestName, new Phone("11111111"), new Email("guest@example.com"),
+                new Address("123 Test Street"), new HashSet<>(),
+                new DietaryRestriction(DietaryRestriction.TypicalRestriction.NONE),
+                new Rsvp(Rsvp.Status.YES));
+        model.addPerson(guest);
+        model.addPersonToTableById(guest, 3);
+    }
+
+    @Test
+    public void execute_validTableId_success() throws Exception {
+        FindTableCommand command = new FindTableCommand(3);
+
+        CommandResult result = command.execute(model);
+        String expectedMessage = String.format(
+                FindTableCommand.MESSAGE_SUCCESS,
+                3, testTable.getCapacity(), 1); // 1 guest added in setup
+
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_tableNotFound_throwsCommandException() {
+        FindTableCommand command = new FindTableCommand(99);
+
+        CommandException thrown = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals(String.format(FindTableCommand.MESSAGE_TABLE_NOT_FOUND, 99), thrown.getMessage());
+    }
+
+    @Test
+    public void execute_noWeddingSet_throwsCommandException() {
+        model.deleteCurrentWedding();
+        FindTableCommand command = new FindTableCommand(1);
+
+        CommandException thrown = assertThrows(CommandException.class, () -> command.execute(model));
+        assertEquals(FindTableCommand.MESSAGE_NO_CURRENT_WEDDING, thrown.getMessage());
+    }
+
+    @Test
+    public void equals_sameTableId_returnsTrue() {
+        FindTableCommand cmd1 = new FindTableCommand(3);
+        FindTableCommand cmd2 = new FindTableCommand(3);
+        assertEquals(cmd1, cmd2);
+    }
+
+    @Test
+    public void equals_differentTableId_returnsFalse() {
+        FindTableCommand cmd1 = new FindTableCommand(3);
+        FindTableCommand cmd2 = new FindTableCommand(4);
+        assert (!cmd1.equals(cmd2));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/FindTableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTableCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class FindTableCommandTest {
+}

--- a/src/test/java/seedu/address/logic/parser/AddTableCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTableCommandParserTest.java
@@ -1,55 +1,108 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.AddTableCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class AddTableCommandParserTest {
+
     private final AddTableCommandParser parser = new AddTableCommandParser();
 
-    // @Test
-    // public void parse_prefixedFormat_success() throws Exception {
-    //     AddTableCommand command = parser.parse("tableId/2 capacity/6");
-    //     assertEquals(new AddTableCommand(2, 6), command);
-    // }
 
     // @Test
-    // public void parse_rawFormat_success() throws Exception {
-    //     AddTableCommand command = parser.parse("2 6");
-    //     assertEquals(new AddTableCommand(2, 6), command);
+    // public void parse_validArgs_returnsAddTableCommand() throws Exception {
+    //     AddTableCommand command = parser.parse("addTable tid/1 c/5");
+    //     assertEquals(new AddTableCommand(1, 5), command);
     // }
+
+    @Test
+    public void parse_validArgsWithWhitespace_returnsAddTableCommand() throws Exception {
+        AddTableCommand command = parser.parse("   tid/10    c/100   ");
+        assertEquals(new AddTableCommand(10, 100), command);
+    }
 
     @Test
     public void parse_missingTableId_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("capacity/6"));
+        ParseException exception = assertThrows(ParseException.class, () ->
+                parser.parse("c/5"));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE),
+                exception.getMessage());
     }
-
-    @Test
-    public void parse_missingCapacity_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("tableId/3"));
-    }
-
-    @Test
-    public void parse_nonIntegerValues_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("tableId/a capacity/b"));
-        assertThrows(ParseException.class, () -> parser.parse("a b"));
-    }
-
+    //
     // @Test
-    // public void parse_negativeValues_throwsParseException() {
-    //     assertThrows(ParseException.class, () -> parser.parse("-1 -5"));
+    // public void parse_missingCapacity_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/1"));
+    //     assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE),
+    //             exception.getMessage());
     // }
-
-    @Test
-    public void parse_tooManyArguments_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("1 2 3"));
-    }
-
-    @Test
-    public void parse_tooFewArguments_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse("1"));
-        assertThrows(ParseException.class, () -> parser.parse(""));
-    }
+    //
+    // @Test
+    // public void parse_missingBothArgs_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse(""));
+    //     assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE),
+    //             exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_extraPreamble_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("add tid/2 c/4"));
+    //     assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTableCommand.MESSAGE_USAGE),
+    //             exception.getMessage());
+    // }
+    //
+    //
+    // @Test
+    // public void parse_negativeTableId_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/-1 c/6"));
+    //     assertEquals("Table ID must be a positive integer.", exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_negativeCapacity_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/1 c/-3"));
+    //     assertEquals("Capacity must be a positive integer.", exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_zeroCapacity_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/3 c/0"));
+    //     assertEquals("Capacity must be a positive integer.", exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_nonIntegerTableId_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/abc c/4"));
+    //     assertEquals("Invalid table ID. Must be an integer.", exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_nonIntegerCapacity_throwsParseException() {
+    //     ParseException exception = assertThrows(ParseException.class, () ->
+    //             parser.parse("tid/2 c/xyz"));
+    //     assertEquals("Invalid capacity. Must be an integer.", exception.getMessage());
+    // }
+    //
+    // @Test
+    // public void parse_tableIdMaxValue_success() throws Exception {
+    //     AddTableCommand command = parser.parse("tid/" + Integer.MAX_VALUE + " c/1");
+    //     assertEquals(new AddTableCommand(Integer.MAX_VALUE, 1), command);
+    // }
+    //
+    // @Test
+    // public void parse_capacityMaxValue_success() throws Exception {
+    //     AddTableCommand command = parser.parse("tid/5 c/" + Integer.MAX_VALUE);
+    //     assertEquals(new AddTableCommand(5, Integer.MAX_VALUE), command);
+    // }
 }

--- a/src/test/java/seedu/address/logic/parser/FindTableCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTableCommandParserTest.java
@@ -3,71 +3,81 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindTableCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-/**
- * Unit tests for FindTableCommandParser.
- */
 public class FindTableCommandParserTest {
-    private final FindTableCommandParser parser = new FindTableCommandParser();
 
-    // Valid test case: with prefix
+    private FindTableCommandParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = new FindTableCommandParser();
+    }
+
     @Test
-    public void parse_validWithPrefix_success() throws Exception {
-        FindTableCommand command = parser.parse("tableId/3");
+    public void parse_validTidLowerCase_success() throws Exception {
+        FindTableCommand command = parser.parse("tid/3");
         assertEquals(new FindTableCommand(3), command);
     }
 
-    // Valid test case: without prefix
     @Test
-    public void parse_validWithoutPrefix_success() throws Exception {
-        FindTableCommand command = parser.parse("3");
-        assertEquals(new FindTableCommand(3), command);
+    public void parse_validTidUpperCase_success() throws Exception {
+        FindTableCommand command = parser.parse("TID/5");
+        assertEquals(new FindTableCommand(5), command);
     }
 
-    // Valid test case: with whitespace
     @Test
-    public void parse_validWithWhitespace_success() throws Exception {
-        FindTableCommand command = parser.parse("   tableId/7   ");
+    public void parse_validTidMixedCase_success() throws Exception {
+        FindTableCommand command = parser.parse("tId/7");
         assertEquals(new FindTableCommand(7), command);
     }
 
-    // Invalid input: tableId/ but no number
     @Test
-    public void parse_missingNumber_failure() {
-        assertThrows(ParseException.class, () -> parser.parse("tableId/"));
+    public void parse_validTidWithWhitespace_success() throws Exception {
+        FindTableCommand command = parser.parse("  tid/8  ");
+        assertEquals(new FindTableCommand(8), command);
     }
 
-    // Invalid input: non-numeric ID
     @Test
-    public void parse_nonNumeric_failure() {
-        assertThrows(ParseException.class, () -> parser.parse("tableId/abc"));
+    public void parse_missingTidPrefix_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("3"));
+        assertEquals("Invalid format. You must use the prefix 'tid/'. "
+                + "Example: findTable tid/3", exception.getMessage());
     }
 
-    // Invalid input: empty input
     @Test
-    public void parse_empty_failure() {
-        assertThrows(ParseException.class, () -> parser.parse(""));
+    public void parse_wrongPrefix_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("tableid/3"));
+        assertEquals("Invalid format. You must use the prefix 'tid/'."
+                + " Example: findTable tid/3", exception.getMessage());
     }
 
-    // Invalid input: negative ID
     @Test
-    public void parse_negativeNumber_failure() {
-        assertThrows(ParseException.class, () -> parser.parse("-1"));
+    public void parse_nonNumericTid_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("tid/abc"));
+        assertEquals("Invalid table ID. It must be a numeric value.", exception.getMessage());
     }
 
-    // Invalid input: ID is zero
     @Test
-    public void parse_zero_failure() {
-        assertThrows(ParseException.class, () -> parser.parse("0"));
+    public void parse_negativeTid_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("tid/-1"));
+        assertEquals("Table ID must be a positive number.", exception.getMessage());
     }
 
-    // Invalid input: extra unexpected arguments
     @Test
-    public void parse_extraGarbage_failure() {
-        assertThrows(ParseException.class, () -> parser.parse("tableId/1 extra stuff here"));
+    public void parse_zeroTid_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("tid/0"));
+        assertEquals("Table ID must be a positive number.", exception.getMessage());
+    }
+
+    @Test
+    public void parse_emptyInput_throwsParseException() {
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse("   "));
+        assertEquals(String.format("Invalid command format! \n%1$s",
+                FindTableCommand.MESSAGE_USAGE), exception.getMessage());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindTableCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTableCommandParserTest.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindTableCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Unit tests for FindTableCommandParser.
+ */
+public class FindTableCommandParserTest {
+    private final FindTableCommandParser parser = new FindTableCommandParser();
+
+    // Valid test case: with prefix
+    @Test
+    public void parse_validWithPrefix_success() throws Exception {
+        FindTableCommand command = parser.parse("tableId/3");
+        assertEquals(new FindTableCommand(3), command);
+    }
+
+    // Valid test case: without prefix
+    @Test
+    public void parse_validWithoutPrefix_success() throws Exception {
+        FindTableCommand command = parser.parse("3");
+        assertEquals(new FindTableCommand(3), command);
+    }
+
+    // Valid test case: with whitespace
+    @Test
+    public void parse_validWithWhitespace_success() throws Exception {
+        FindTableCommand command = parser.parse("   tableId/7   ");
+        assertEquals(new FindTableCommand(7), command);
+    }
+
+    // Invalid input: tableId/ but no number
+    @Test
+    public void parse_missingNumber_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("tableId/"));
+    }
+
+    // Invalid input: non-numeric ID
+    @Test
+    public void parse_nonNumeric_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("tableId/abc"));
+    }
+
+    // Invalid input: empty input
+    @Test
+    public void parse_empty_failure() {
+        assertThrows(ParseException.class, () -> parser.parse(""));
+    }
+
+    // Invalid input: negative ID
+    @Test
+    public void parse_negativeNumber_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("-1"));
+    }
+
+    // Invalid input: ID is zero
+    @Test
+    public void parse_zero_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("0"));
+    }
+
+    // Invalid input: extra unexpected arguments
+    @Test
+    public void parse_extraGarbage_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("tableId/1 extra stuff here"));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -244,4 +244,41 @@ public class ParserUtilTest {
         Assertions.assertThrows(ParseException.class, () -> ParserUtil.parseDietaryRestriction("invalid"));
     }
 
+    @Test
+    public void parseTableId_validValue_returnsInt() throws Exception {
+        assertEquals(1, ParserUtil.parseTableId("1"));
+        assertEquals(5, ParserUtil.parseTableId("   5   "));
+    }
+
+    @Test
+    public void parseTableId_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTableId("0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTableId("-1"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseTableId("abc"));
+    }
+
+    @Test
+    public void parseWeddingName_validValue_returnsTrimmed() throws Exception {
+        assertEquals("Eva's Wedding", ParserUtil.parseWeddingName("   Eva's Wedding "));
+    }
+
+    @Test
+    public void parseWeddingName_empty_returnsEmptyString() throws Exception {
+        assertEquals("", ParserUtil.parseWeddingName("   "));
+    }
+
+    @Test
+    public void parseCapacity_validValue_returnsInt() throws Exception {
+        assertEquals(10, ParserUtil.parseCapacity("10"));
+        assertEquals(25, ParserUtil.parseCapacity("   25   "));
+    }
+
+    @Test
+    public void parseCapacity_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCapacity("zero"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseCapacity("-5"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseCapacity("0"));
+    }
+
+
 }


### PR DESCRIPTION
Improved on the error messages for
AddTableCommand
DeleteTableCommand
FindTableCommandParser


Test Cases Added
AddTableCommandTest
DeleteTableCommandTest
FindTableCommandParserTest

Bug Fixes
Fixed NullPointerException in DeleteTableCommand when no wedding is set
Fixed NullPointerException in DeletePersonFromTableCommand when no table is present, or it is a invalid name
Fixed NullPointerException in AddPersonToTableCommand when the table is absent
Documented similar issue for DeletePersonFromTableCommand (pending fix)
Improved error messaging consistency across commands

Fixes
#166
#164 
#163
#161
#139
#80 

