### PR TITLE
Update DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -293,7 +293,7 @@ Olivia is a professional wedding planner with 5 years of experience organising c
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-<<<<<<< HEAD
+
 | Priority | As a...                                                 | I want to...                                                                                 | So that I can                                                                              |
 |----------|---------------------------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
 | ***      | wedding planner                                         | make changes to my clients plans                                                               |                                                                                            |
@@ -314,32 +314,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | *        | wedding planner                                         | create a library of preferred vendors and pricing details                                      | easily recommend the best options to my clients                                            |
 | *        | wedding planner                                         | get a contact list of wedding-related vendors nearby                                           | I don’t have to worry about looking them up personally                                     |
 | *        | wedding planner                                         | track expenses against a set budget                                                            | I stay informed of the wedding costs                                                       |
-=======
-| Priority | As a...                                                 | I want to...                                                                                 | So that I can                                                                                                  |
-|----------|---------------------------------------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| ***      | wedding planner                                         | make changes to my clients plans                                                               |                                                                                                                |
-| ***      | wedding planner of a couple that can't make up their mind | add and delete the guest list                                                                  | should the couple decide to make changes                                                                       |
-| ***      | wedding planner of a couple with lots of guests         | indicate whether a guest is confirmed, unconfirmed, or cancelled                               | cater enough food for them                                                                                     |
-| ***      | wedding planner                                         | keep track of dietary restrictions for guests                                                  | ensure the catering meets everyone's needs                                                                     |
-| ***      | wedding planner                                         | track guest RSVPs and their meal preferences                                                   | finalise catering and seating arrangements efficiently                                                         |
-| ***      | wedding planner                                         | assign guests to tables                                                                        | ensure no seats are left empty within a table                                                                  |
-| ***      | wedding planner of high profile clients                 | store information about guests like contact details, address                                   | send out personalised invitation cards                                                                         |
-| ***      | wedding planner                                         | see a quick overview of a specific wedding                                                     | easily determine the number of guests and tables currently assigned to my client's wedding                    |
-| ***      | wedding planner with multiple clients                   | view the entire guest list assigned to one of my weddings easily                               | quickly look through guests' information                                                                       |
-| ***      | experienced wedding planner                             | set the number of tables early to gauge the number of guests my client has                     | easily manage other logistics such as venue decision, food catering etc.                                      |
-| ***      | wedding planner                                         | decide how many guests should be seated at one table                                           | customise it to my clients' needs                                                                              |
-| ***      | wedding planner                                         | view the entire table list quickly                                                             | quickly see the list of tables and their capacities                                                           |
-| **       | organised wedding planner                               | filter guests based on their dietary restrictions and RSVP status                              | view guests based on a specific category                                                                       |
-| **       | wedding planner                                         | maintain personal notes and comments on tasks                                                  | keep track of important details and task progress                                                             |
-| *        | forgetful wedding planner                               | mark the status of the vendor list                                                             | keep track of whether a vendor has confirmed                                                                   |
-| *        | detailed wedding planner                                | see a list of upcoming tasks that are most urgent                                              | pay attention to them first                                                                                    |
-| *        | wedding planner                                         | create a library of preferred vendors and pricing details                                      | easily recommend the best options to my clients                                                                |
-| *        | wedding planner                                         | send scheduled messages to the guests, vendors, and photographers                              | they can be reminded of the upcoming schedule and deadlines                                                    |
-| *        | wedding planner                                         | get a contact list of wedding-related vendors nearby                                           | I don't have to worry about looking them up personally                                                         |
-| *        | wedding planner                                         | track expenses against a set budget                                                            | I stay informed of the wedding costs                                                                           |
-| *        | wedding planner                                         | share a to-do list with my clients                                                             | we can stay on the same page about what needs to be done                                                       |
->>>>>>> upstream/master
-
 
 ## Use cases (UC)
 
@@ -348,23 +322,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ### UC1: Create a wedding
 
 **MSS**
-
-<<<<<<< HEAD
-1. User wants to create a new wedding.
-2. User enters the wedding name using the command, e.g., `createWedding John & Jane Wedding`.
-3. WeddingHero validates the input details.
-4. WeddingHero creates a new wedding entry in the system.
-5. WeddingHero confirms the successful creation of the wedding. 
-
-Use case ends.
-=======
 1. User requests to create a new wedding.
 2. User provides the wedding name.
 3. System validates the wedding name.
 4. System creates the new wedding.
 5. System confirms the wedding has been created.
    Use case ends.
->>>>>>> upstream/master
 
 **Extensions:**
 
@@ -413,53 +376,26 @@ Use case ends.
 **Extensions:**
 
 2a. **Missing Wedding Name**
-<<<<<<< HEAD
-   - 2a1. If the user issues the command without providing a wedding name, WeddingHero displays an error message indicating that the wedding name is required.
-   - 2a2. WeddingHero prompts the user to re-enter the command with the correct format.
-   - 2a3. Upon receiving the correct input, the process resumes at step 3.
+- 2a1. System detects that no wedding name was provided.
+- 2a2. System informs the user that a wedding name is required.
+- 2a3. System prompts the user to provide a wedding name.
+- 2a4. If the user provides a wedding name, the process resumes at step 3.
 
 2b. **Non-Existent Wedding**
-   - 2b1. If the specified wedding name does not match any existing wedding, WeddingHero informs the user that no such wedding was found.
-   - 2b2. WeddingHero prompts the user to either re-enter a valid wedding name or cancel the operation.
-   - 2b3. If the user provides a valid wedding name, the process resumes at step 3; if the user cancels, the use case ends.
-
-2c. **Invalid Input Format**
-   - 2c1. If the user enters invalid text or an unsupported format for the wedding name, WeddingHero displays an error message indicating the input is invalid.
-   - 2c2. WeddingHero prompts the user to re-enter the command in the correct format.
-   - 2c3. Once valid input is provided, the process resumes at step 3.
-=======
-    2a1. System detects that no wedding name was provided.
-    2a2. System informs the user that a wedding name is required.
-    2a3. System prompts the user to provide a wedding name.
-    2a4. If the user provides a wedding name, the process resumes at step 3.
-
-2b. **Non-Existent Wedding**
-    2b1. System cannot find the specified wedding.
-    2b2. System informs the user that the wedding does not exist.
-    2b3. System prompts the user to provide a valid wedding name.
-    2b4. If the user provides a valid wedding name, the process resumes at step 3.
->>>>>>> upstream/master
+- 2b1. System cannot find the specified wedding.
+- 2b2. System informs the user that the wedding does not exist.
+- 2b3. System prompts the user to provide a valid wedding name.
+- 2b4. If the user provides a valid wedding name, the process resumes at step 3.
 
 ---
 
 ### UC3: Wedding Overview
 
 **Preconditions:**
-- A wedding has been created.
-<<<<<<< HEAD
 - The wedding has been set as the active wedding in WeddingHero.
 
-**MSS**
-
-1. User wants to view the wedding overview.
-2. WeddingHero retrieves the overview details of the current active wedding, including the number of tables, guests and list of guests.
-3. WeddingHero displays the wedding overview information.
-4. Use case ends.
-=======
-- A wedding has been set as the active wedding.
 
 **MSS**
-
 1. User requests to view the wedding overview.
 2. System retrieves the overview details of the current active wedding, including:
    - Number of tables
@@ -467,27 +403,18 @@ Use case ends.
    - List of guests
 3. System displays the wedding overview information.
    Use case ends.
->>>>>>> upstream/master
 
 **Extensions:**
 
 2a. **No Active Wedding Set**
-<<<<<<< HEAD
-    
-- 2a1. If no active wedding is set, WeddingHero informs the user that an active wedding must be set before viewing an overview.
-- 2a2. WeddingHero prompts the user to set a wedding.
-- 2a3. Once an active wedding is set, the user may reissue the wedding overview command, and the process resumes at
-    step 2.
-=======
-    2a1. System detects that no wedding is currently set.
-    2a2. System informs the user that an active wedding must be set first.
-    2a3. System prompts the user to set a wedding as active.
-    2a4. Once a wedding is set as active, the user may request the overview again.
->>>>>>> upstream/master
+- 2a1. System detects that no wedding is currently set.
+- 2a2. System informs the user that an active wedding must be set first.
+- 2a3. System prompts the user to set a wedding as active.
+- 2a4. Once a wedding is set as active, the user may request the overview again.
 
 ---
 
-### UC4: Add a Person
+### UC4: Add a Guest
 
 **Preconditions:**
 - A wedding has been created.
@@ -506,32 +433,31 @@ Use case ends.
 3. System validates the provided details.
 4. System adds the guest to the current wedding's guest list.
 5. System confirms that the guest has been added successfully.
-
    Use case ends.
 
 **Extensions:**
 
 2a. **Missing Required Information**
-    2a1. System detects that required guest information is missing.
-    2a2. System informs the user which information is required.
-    2a3. System prompts the user to provide the missing information.
-    2a4. If the user provides the required information, the process resumes at step 3.
+- 2a1. System detects that required guest information is missing.
+- 2a2. System informs the user which information is required.
+- 2a3. System prompts the user to provide the missing information.
+- 2a4. If the user provides the required information, the process resumes at step 3.
 
 2b. **Invalid Information Format**
-    2b1. System detects that some information is in an invalid format.
-    2b2. System informs the user which information is invalid and why.
-    2b3. System prompts the user to correct the invalid information.
-    2b4. If the user provides valid information, the process resumes at step 3.
+- 2b1. System detects that some information is in an invalid format.
+- 2b2. System informs the user which information is invalid and why.
+- 2b3. System prompts the user to correct the invalid information.
+- 2b4. If the user provides valid information, the process resumes at step 3.
 
 2c. **Duplicate Guest**
-    2c1. System detects that a guest with the same name already exists.
-    2c2. System informs the user that the guest already exists.
-    2c3. System prompts the user to either modify the guest's name or cancel.
-    2c4. If the user provides unique name, the process resumes at step 3.
+- 2c1. System detects that a guest with the same name already exists.
+- 2c2. System informs the user that the guest already exists.
+- 2c3. System prompts the user to either modify the guest's name or cancel.
+- 2c4. If the user provides unique name, the process resumes at step 3.
 
 ---
 
-### UC5: Delete a person
+### UC5: Delete a Guest
 
 **Preconditions:**
 - A wedding has been created.
@@ -603,11 +529,12 @@ Use case ends.
 
 **MSS**
 1. User decides to add a new table.
-2. User enters the command eg. `addTable tid/4 c/8` with the desired table's ID and capacity.
+2. User enters the command the table ID.
 3. WeddingHero validates that the table ID is unique and that the capacity is a valid positive integer.
-4. WeddingHero adds the table to the current wedding selected by `setWedding`.
-5. WeddingHero displays a confirmation message indicating that the table has been successfully added.
-6. Use case ends.
+4. WeddingHero adds the table to the current wedding 
+5. WeddingHero displays a confirmation message indicating that the table has been successfully added. 
+
+Use case ends.
 
 **Extensions:**
 
@@ -641,10 +568,10 @@ Use case ends.
 **MSS**
 1. User requests to delete a table.
 2. User provides the table ID.
-3. System verifies the table exists.
-4. System removes the table from the wedding layout.
-5. System confirms that the table has been deleted.
-   Use case ends.
+3. WeddingHero checks if the table exists.
+4. WeddingHero deletes the table from the layout.
+5. WeddingHero confirms that the table has been deleted.
+Use case ends.
 
 **Extensions:**
 
@@ -659,29 +586,28 @@ Use case ends.
 - 2b3. If the user provides a valid table ID, the process resumes at step 3. Otherwise, use case ends.
 
 ---
-### UC8: Assign a person to a table
+### UC8: Assign a Guest to a table
 
 **Preconditions:**
 - A wedding has been created.
 - The wedding has been set as the active wedding in WeddingHero.
-- At least one person and one table exist in the current wedding.
+- At least one table has been created.
+- The guest to be added has already been added to the wedding
 
 **MSS**
 
-1. User decides to assign a guest to a table.
-2. User enters the command in the correct format:  
-   `addPersonToTable n/John Doe tid/1`
-3. WeddingHero checks if the specified person exists.
-4. WeddingHero checks if the specified table exists and has available capacity.
-5. WeddingHero assigns the person to the specified table.
-6. WeddingHero displays a confirmation message that the person has been successfully assigned.  
-   Use case ends.
+1. User requests to assign a guest to a table.
+2. User adds the table and the guest
+3. WeddingHero verifies that the guest and table exist.
+4. WeddingHero assigns the guest to the specified table.
+5. WeddingHero displays a confirmation message.
+Use case ends.
 
 **Extensions:**
 
 3a. **Person Not Found**
-- 3a1. If the specified person does not exist, WeddingHero informs the user.
-- 3a2. User is prompted to re-enter a valid person name.
+- 3a1. If the specified guest does not exist, WeddingHero informs the user.
+- 3a2. User is prompted to re-enter a valid guest name.
 - 3a3. Upon valid input, the process resumes at step 3.
 
 4a. **Table Not Found**
@@ -700,7 +626,7 @@ Use case ends.
 
 ---
 
-### UC9: Remove a person from a table
+### UC9: Remove a Guest from a table
 
 **Preconditions:**
 - A wedding has been created.
@@ -708,18 +634,17 @@ Use case ends.
 - A person has already been assigned to a table.
 
 **MSS**
-1. User decides to remove a person from a table.
-2. User enters the command in the correct format:  
-   `deletePersonFromTable n/John Doe tid/1`
+1. User decides to remove a guest from a table.
+2. User enters the table and the guest to be removed
 3. WeddingHero checks if the specified person exists and is assigned to the specified table.
 4. WeddingHero removes the person from the table.
-5. WeddingHero displays a confirmation message that the person has been successfully removed from the table.  
+5. WeddingHero displays a confirmation message that the guest has been successfully removed from the table.  
    Use case ends.
 
 **Extensions:**
 
-3a. **Person Not Found**
-- 3a1. If the specified person does not exist, WeddingHero informs the user.
+3a. **Guest Not Found**
+- 3a1. If the specified guest does not exist, WeddingHero informs the user.
 - 3a2. User is prompted to re-enter a valid person name.
 - 3a3. Upon valid input, the process resumes at step 3.
 
@@ -728,7 +653,7 @@ Use case ends.
 - 3b2. User is prompted to re-enter a valid table ID.
 - 3b3. Upon valid input, the process resumes at step 3.
 
-3c. **Person Not Assigned to Table**
+3c. **Guest Not Assigned to Table**
 - 3c1. If the person is not assigned to the specified table, WeddingHero informs the user.
 - 3c2. User may choose to cancel or try another table ID.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -12,6 +12,9 @@ pageNav: 3
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Acknowledgements**
+- The project is based on the AddressBook-Level2 project created by the SE-EDU initiative
+- Github CoPilot was used by Bhavina Sathish Kumar to write trivial test cases and the JavaDocs for some trivial methods
+
 
 _{ list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well }_
 
@@ -271,34 +274,33 @@ Olivia is a professional wedding planner with 5 years of experience organising c
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a...                                                 | I want to...                                                                                 | So that I can                                                                                                  |
-|----------|---------------------------------------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| ***      | wedding planner                                         | make changes to my clients plans                                                               |                                                                                                                |
-| ***      | wedding planner of a couple that can’t make up their mind | add and delete the guest list                                                                  | should the couple decide to make changes                                                                       |
-| ***      | wedding planner of a couple with lots of guests         | indicate whether a guest is confirmed, unconfirmed, or cancelled                               | cater enough food for them                                                                                     |
-| ***      | wedding planner                                         | keep track of dietary restrictions for guests                                                  | ensure the catering meets everyone’s needs                                                                     |
-| ***      | wedding planner                                         | track guest RSVPs and their meal preferences                                                   | finalise catering and seating arrangements efficiently                                                         |
-| ***      | wedding planner                                         | assign guests to tables                                                                        | ensure no seats are left empty within a table                                                                  |
-| ***      | wedding planner of high profile clients                 | store information about guests like contact details, address                                   | send out personalised invitation cards                                                                         |
-| ***      | wedding planner                                         | see a quick overview of a specific wedding                                                     | easily determine the number of guests and tables currently assigned to my client's wedding                    |
-| ***      | wedding planner with multiple clients                   | view the entire guest list assigned to one of my weddings easily                               | quickly look through guests’ information                                                                       |
-| ***      | experienced wedding planner                             | set the number of tables early to gauge the number of guests my client has                     | easily manage other logistics such as venue decision, food catering etc.                                      |
-| ***      | wedding planner                                         | decide how many guests should be seated at one table                                           | customise it to my clients’ needs                                                                              |
-| ***      | wedding planner                                         | view the entire table list quickly                                                             | quickly see the list of tables and their capacities                                                           |
-| **       | organised wedding planner                               | filter guests based on their dietary restrictions and RSVP status                              | view guests based on a specific category                                                                       |
-| *        | forgetful wedding planner                               | mark the status of the vendor list                                                             | keep track of whether a vendor has confirmed                                                                   |
-| *        | detailed wedding planner                                | see a list of upcoming tasks that are most urgent                                              | pay attention to them first                                                                                    |
-| *        | wedding planner                                         | create a library of preferred vendors and pricing details                                      | easily recommend the best options to my clients                                                                |
-| *        | wedding planner                                         | send scheduled messages to the guests, vendors, and photographers                              | they can be reminded of the upcoming schedule and deadlines                                                    |
-| *        | wedding planner                                         | get a contact list of wedding-related vendors nearby                                           | I don’t have to worry about looking them up personally                                                         |
-| *        | wedding planner                                         | track expenses against a set budget                                                            | I stay informed of the wedding costs                                                                           |
-| *        | wedding planner                                         | share a to-do list with my clients                                                             | we can stay on the same page about what needs to be done                                                       |
+| Priority | As a...                                                 | I want to...                                                                                 | So that I can                                                                              |
+|----------|---------------------------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| ***      | wedding planner                                         | make changes to my clients plans                                                               |                                                                                            |
+| ***      | wedding planner of a couple that can’t make up their mind | add and delete the guest list                                                                  | change the guest list should the couple decide to make changes                             |
+| ***      | wedding planner of a couple with lots of guests         | indicate whether a guest is confirmed, unconfirmed, or cancelled                               | cater enough food for them                                                                 |
+| ***      | wedding planner                                         | keep track of dietary restrictions for guests                                                  | ensure the catering meets everyone’s needs                                                 |
+| ***      | wedding planner                                         | track guest RSVPs and their meal preferences                                                   | finalise catering and seating arrangements efficiently                                     |
+| ***      | wedding planner                                         | assign guests to tables                                                                        | ensure no seats are left empty within a table                                              |
+| ***      | wedding planner of high profile clients                 | store information about guests like contact details, address                                   | send out personalised invitation cards                                                     |
+| ***      | wedding planner                                         | see a quick overview of a specific wedding                                                     | easily determine the number of guests and tables currently assigned to my client's wedding |
+| ***      | wedding planner with multiple clients                   | view the entire guest list assigned to one of my weddings easily                               | quickly look through guests’ information                                                   |
+| ***      | experienced wedding planner                             | set the number of tables early to gauge the number of guests my client has                     | easily manage other logistics such as venue decision, food catering etc.                   |
+| ***      | wedding planner                                         | decide how many guests should be seated at one table                                           | customise it to my clients’ needs                                                          |
+| ***      | wedding planner                                         | view the entire table list quickly                                                             | quickly see the list of tables and their capacities                                        |
+| **       | organised wedding planner                               | filter guests based on their dietary restrictions and RSVP status                              | view guests based on a specific category                                                   |
+| *        | forgetful wedding planner                               | mark the status of the vendor list                                                             | keep track of whether a vendor has confirmed                                               |
+| *        | detailed wedding planner                                | see a list of upcoming tasks that are most urgent                                              | pay attention to them first                                                                |
+| *        | wedding planner                                         | create a library of preferred vendors and pricing details                                      | easily recommend the best options to my clients                                            |
+| *        | wedding planner                                         | get a contact list of wedding-related vendors nearby                                           | I don’t have to worry about looking them up personally                                     |
+| *        | wedding planner                                         | track expenses against a set budget                                                            | I stay informed of the wedding costs                                                       |
 
-## Use cases
+
+## Use cases (UC)
 
 (For all use cases below, the **System** is the `WeddingHero` and the **Actor** is the `user`, unless specified otherwise)
 
-### Use case: Create a wedding
+### UC1: Create a wedding
 
 **MSS**
 
@@ -306,12 +308,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 2. User enters the wedding name using the command, e.g., `createWedding John & Jane Wedding`.
 3. WeddingHero validates the input details.
 4. WeddingHero creates a new wedding entry in the system.
-5. WeddingHero confirms the successful creation of the wedding.
-   Use case ends.
+5. WeddingHero confirms the successful creation of the wedding. 
+
+Use case ends.
 
 ---
 
-### Use case: Set a wedding
+### UC2: Set a wedding
 
 **Preconditions:**
 - At least one wedding has been created in WeddingHero.
@@ -328,27 +331,27 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Extensions:**
 
 2a. **Missing Wedding Name**
-   2a1. If the user issues the command without providing a wedding name, WeddingHero displays an error message indicating that the wedding name is required.
-   2a2. WeddingHero prompts the user to re-enter the command with the correct format.
-   2a3. Upon receiving the correct input, the process resumes at step 3.
+   - 2a1. If the user issues the command without providing a wedding name, WeddingHero displays an error message indicating that the wedding name is required.
+   - 2a2. WeddingHero prompts the user to re-enter the command with the correct format.
+   - 2a3. Upon receiving the correct input, the process resumes at step 3.
 
 2b. **Non-Existent Wedding**
-   2b1. If the specified wedding name does not match any existing wedding, WeddingHero informs the user that no such wedding was found.
-   2b2. WeddingHero prompts the user to either re-enter a valid wedding name or cancel the operation.
-   2b3. If the user provides a valid wedding name, the process resumes at step 3; if the user cancels, the use case ends.
+   - 2b1. If the specified wedding name does not match any existing wedding, WeddingHero informs the user that no such wedding was found.
+   - 2b2. WeddingHero prompts the user to either re-enter a valid wedding name or cancel the operation.
+   - 2b3. If the user provides a valid wedding name, the process resumes at step 3; if the user cancels, the use case ends.
 
 2c. **Invalid Input Format**
-   2c1. If the user enters invalid text or an unsupported format for the wedding name, WeddingHero displays an error message indicating the input is invalid.
-   2c2. WeddingHero prompts the user to re-enter the command in the correct format.
-   2c3. Once valid input is provided, the process resumes at step 3.
+   - 2c1. If the user enters invalid text or an unsupported format for the wedding name, WeddingHero displays an error message indicating the input is invalid.
+   - 2c2. WeddingHero prompts the user to re-enter the command in the correct format.
+   - 2c3. Once valid input is provided, the process resumes at step 3.
 
 ---
 
-### Use case: Wedding Overview
+### UC3: Wedding Overview
 
 **Preconditions:**
 - A wedding has been created.
-- A wedding has been set as the active wedding in WeddingHero.
+- The wedding has been set as the active wedding in WeddingHero.
 
 **MSS**
 
@@ -360,24 +363,25 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Extensions:**
 
 2a. **No Active Wedding Set**
-    2a1. If no active wedding is set, WeddingHero informs the user that an active wedding must be set before viewing an overview.
-    2a2. WeddingHero prompts the user to set a wedding.
-    2a3. Once an active wedding is set, the user may reissue the wedding overview command, and the process resumes at
+    
+- 2a1. If no active wedding is set, WeddingHero informs the user that an active wedding must be set before viewing an overview.
+- 2a2. WeddingHero prompts the user to set a wedding.
+- 2a3. Once an active wedding is set, the user may reissue the wedding overview command, and the process resumes at
     step 2.
 
 ---
 
-### Use case: Add a guest
+### UC4: Add a guest
 
 **Preconditions:**
 - A wedding has been created.
-- A wedding has been set as the active wedding in WeddingHero.
+- The wedding has been set as the active wedding in WeddingHero.
 
 **MSS**
 
 1. User decides to add a new guest.
 2. User to enters the guest details in the following correct format:
-   `addGuest n/john Doe p/81231234 e/JohnDoe@gmail.com a/123 Kent Ridge d/None r/YES`
+   `addPerson n/john Doe p/81231234 e/JohnDoe@gmail.com a/123 Kent Ridge d/None r/YES`
 3. WeddingHero validates the entered details.
 4. WeddingHero adds the guest to the current wedding's guest list.
 5. WeddingHero displays a confirmation message that the guest has been successfully added.
@@ -386,29 +390,29 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Extensions:**
 
 2a. **Missing Required Tag**
-    2a1. If the user omits one or more required identifier tags (e.g. `n/`, `p/`, etc.).
-    2a2. WeddingHero displays an error message displaying the correct format, along with an example.
-    2a3. Upon receiving the correct input, the process resumes at step 3.
+- 2a1. If the user omits one or more required identifier tags (e.g. `n/`, `p/`, etc.).
+- 2a2. WeddingHero displays an error message displaying the correct format, along with an example.
+- 2a3. Upon receiving the correct input, the process resumes at step 3.
 
 2b. **Invalid Phone number**
-    2b1. If the user enters an invalid phone number containing non numbers (e.g. 8124123A).
-    2b2. WeddingHero displays an error message, informing user that numbers are only allowed for phone number.
-    2b3. Once valid input is provided, the process resumes at step 3.
+- 2b1. If the user enters an invalid phone number containing non numbers (e.g. 8124123A).
+- 2b2. WeddingHero displays an error message, informing user that numbers are only allowed for phone number.
+- 2b3. Once valid input is provided, the process resumes at step 3.
 
 2b. **Invalid Email address**
-    2c1. If the user enters an invalid email address (e.g. joe@).
-    2c2. WeddingHero displays an error message, informing user the requirements for a valid email address.
-    2c3. Once valid input is provided, the process resumes at step 3.
+- 2c1. If the user enters an invalid email address (e.g. joe@). 
+- 2c2. WeddingHero displays an error message, informing user the requirements for a valid email address.
+- 2c3. Once valid input is provided, the process resumes at step 3.
 
 3c. **Duplicate Person**
-    3c1. If WeddingHero detects that a guest with the same identifier (e.g. same name) already exists,
+- 3c1. If WeddingHero detects that a guest with the same identifier (e.g. same name) already exists,
     it notifies the user of the duplicate.
-    3c2. WeddingHero prompts the user that guest has already been added.
-    Use case ends.
+- 3c2. WeddingHero prompts the user that guest has already been added.
+Use case ends.
 
 ---
 
-### Use case: Delete a guest
+### UC5: Delete a guest
 
 **Preconditions:**
 - A wedding has been created.
@@ -418,39 +422,39 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 1. User requests to view the current guest list.
 2. WeddingHero displays the list of guests.
-3. User selects a guest to delete by providing an identifier (guest name), e.g., `deleteGuest n/John Doe`.
-4. WeddingHero searches for a guest matching the provided name or phone number.
+3. User selects a guest to delete by providing an identifier (guest name), e.g., `deletePerson n/John Doe`.
+4. WeddingHero searches for a guest matching the provided nam
 5. WeddingHero deletes the guest.
    Use case ends.
 
 **Extensions:**
 
 3a. **Alternative Identifier: Phone Number**
-    3a1. Instead of using the guest name, the user issues the delete command with a phone number identifier (e.g., `deleteGuest p/81231234`).
-    3a2. WeddingHero searches for a guest matching the provided phone number.
-    3a3. WeddingHero then proceeds to step 5 of the MSS.
+- 3a1. Instead of using the guest name, the user issues the delete command with a phone number identifier (e.g., `deleteGuest p/81231234`).
+- 3a2. WeddingHero searches for a guest matching the provided phone number.
+- 3a3. WeddingHero then proceeds to step 5 of the MSS.
 
 3b. **Missing Identifier Tag**
-    3b1. The user issues the delete command without using the required identifier tag (e.g., `deleteGuest John Doe` without `n/` or `p/`).
-    3b2. WeddingHero detects the missing tag and displays an error message instructing the user to use the correct identifier format.
-    3b3. WeddingHero prompts the user to re-enter the command with either of the proper tags.
-    3b4. If the user re-enters the command with a valid identifier, the process resumes at step 4.
+- 3b1. The user issues the delete command without using the required identifier tag (e.g., `deleteGuest John Doe` without `n/` or `p/`).
+- 3b2. WeddingHero detects the missing tag and displays an error message instructing the user to use the correct identifier format.
+- 3b3. WeddingHero prompts the user to re-enter the command with either of the proper tags.
+- 3b4. If the user re-enters the command with a valid identifier, the process resumes at step 4.
 
 3c. **Invalid Input Text**
-    3c1. The user enters invalid text that does not conform to the expected format (e.g., contains non-alphanumeric characters).
-    3c2. WeddingHero identifies the invalid input and displays an error message indicating that the input is invalid.
-    3c3. WeddingHero prompts the user to re-enter a valid identifier.
-    3c4. If the user provides a valid input, the process resumes at step 4.
+- 3c1. The user enters invalid text that does not conform to the expected format (e.g., contains non-alphanumeric characters).
+- 3c2. WeddingHero identifies the invalid input and displays an error message indicating that the input is invalid.
+- 3c3. WeddingHero prompts the user to re-enter a valid identifier.
+- 3c4. If the user provides a valid input, the process resumes at step 4.
 
 5a. **No Matching Person Found**
-    5a1. WeddingHero is unable to find any guest matching the provided identifier (name or phone number).
-    5a2. WeddingHero informs the user that no matching guest was found.
-    5a3. If the user re-enters a valid tag with a different value as an identifier, the process resumes at step 4.
-    5a4. If the user changes commands, the use case ends.
+- 5a1. WeddingHero is unable to find any guest matching the provided identifier (name or phone number).
+- 5a2. WeddingHero informs the user that no matching guest was found.
+- 5a3. If the user re-enters a valid tag with a different value as an identifier, the process resumes at step 4.
+- 5a4. If the user changes commands, the use case ends.
 
 ---
 
-### Use case: Add a table
+### UC6: Add a table
 
 **Preconditions:**
 - A wedding has been created.
@@ -468,27 +472,28 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Extensions:**
 
 2a. **Missing Required Details**
-   2a1. If the user omits the table ID or capacity, WeddingHero displays an error message indicating that both parameters are required.
-   2a2. WeddingHero prompts the user to re-enter the command with the correct format.
-   2a3. Once the correct input is provided, the process resumes at step 3.
+- 2a1. If the user omits the table ID or capacity, WeddingHero displays an error message indicating that both parameters are required.
+- 2a2. WeddingHero prompts the user to re-enter the command with the correct format.
+- 2a3. Once the correct input is provided, the process resumes at step 3.
 
 2b. **Invalid Capacity**
-   2b1. If the user enters an invalid capacity (e.g. a non-numeric value or a negative number), WeddingHero displays an error message specifying that the capacity must be a positive integer.
-   2b2. WeddingHero prompts the user to re-enter the command with a valid capacity (e.g. positive numeric number).
-   2b3. Once a valid capacity is provided, the process resumes at step 3.
+- 2b1. If the user enters an invalid capacity (e.g. a non-numeric value or a negative number), WeddingHero displays an error message specifying that the capacity must be a positive integer.
+- 2b2. WeddingHero prompts the user to re-enter the command with a valid capacity (e.g. positive numeric number).
+- 2b3. Once a valid capacity is provided, the process resumes at step 3.
 
 2c. **Duplicate Table ID**
-   2c1. If a table with the provided table ID already exists in the current wedding layout, WeddingHero notifies the user of the duplicate.
-   2c2. WeddingHero prompts the user to enter a new unique table ID.
-   2c3. If a new, unique table ID is provided, the process resumes at step 3; if the user cancels, the use case ends.
+- 2c1. If a table with the provided table ID already exists in the current wedding layout, WeddingHero notifies the user of the duplicate.
+- 2c2. WeddingHero prompts the user to enter a new unique table ID.
+- 2c3. If a new, unique table ID is provided, the process resumes at step 3; if the user cancels, the use case ends.
 
 ---
 
-### Use case: Delete a table
+### UC7: Delete a table
 
 **Preconditions:**
 - A wedding has been created.
 - A wedding has been set as the active wedding in WeddingHero.
+- The table to be deleted is created
 
 **MSS**
 
@@ -505,18 +510,94 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **Extensions:**
 
 2a. **Missing Table ID**
-   2a1. If the user omits the table ID when entering the command, WeddingHero displays an error message indicating that the table ID is required.
-   2a2. WeddingHero prompts the user to re-enter the command with the correct format.
-   2a3. Once the correct input is provided, the process resumes at step 3.
+- 2a1. If the user omits the table ID when entering the command, WeddingHero displays an error message indicating that the table ID is required.
+- 2a2. WeddingHero prompts the user to re-enter the command with the correct format.
+- 2a3. Once the correct input is provided, the process resumes at step 3.
 
 2b. **Table Not Found**
-   2b1. If WeddingHero is unable to locate a table matching the provided ID, it informs the user that no matching table was found.
-   2b2. WeddingHero prompts the user to either re-enter a valid table ID.
-   2b3. If the user provides a valid table ID, the process resumes at step 3. Otherwise, use case ends.
+- 2b1. If WeddingHero is unable to locate a table matching the provided ID, it informs the user that no matching table was found.
+- 2b2. WeddingHero prompts the user to either re-enter a valid table ID.
+- 2b3. If the user provides a valid table ID, the process resumes at step 3. Otherwise, use case ends.
+
+---
+### UC8: Assign a person to a table
+
+**Preconditions:**
+- A wedding has been created.
+- The wedding has been set as the active wedding in WeddingHero.
+- At least one person and one table exist in the current wedding.
+
+**MSS**
+
+1. User decides to assign a guest to a table.
+2. User enters the command in the correct format:  
+   `addPersonToTable n/John Doe tid/1`
+3. WeddingHero checks if the specified person exists.
+4. WeddingHero checks if the specified table exists and has available capacity.
+5. WeddingHero assigns the person to the specified table.
+6. WeddingHero displays a confirmation message that the person has been successfully assigned.  
+   Use case ends.
+
+**Extensions:**
+
+3a. **Person Not Found**
+- 3a1. If the specified person does not exist, WeddingHero informs the user.
+- 3a2. User is prompted to re-enter a valid person name.
+- 3a3. Upon valid input, the process resumes at step 3.
+
+4a. **Table Not Found**
+- 4a1. If the table ID does not match any existing table, WeddingHero informs the user.
+- 4a2. User is prompted to re-enter a valid table ID.
+- 4a3. Upon valid input, the process resumes at step 4.
+
+4b. **Table Full**
+- 4b1. If the table has reached its maximum capacity, WeddingHero displays an error message.
+- 4b2. User is prompted to select another table or modify the table capacity.
+- 4b3. If the user selects another table, the process resumes at step 4.
+
+2a. **Invalid Input Format**
+- 2a1. If the input is missing required fields or incorrectly formatted, WeddingHero displays an error message showing the correct format.
+- 2a2. Upon receiving the correct input, the process resumes at step 3.
 
 ---
 
-*{More to be added}*
+### UC9: Remove a person from a table
+
+**Preconditions:**
+- A wedding has been created.
+- The wedding has been set as the active wedding in WeddingHero.
+- A person has already been assigned to a table.
+
+**MSS**
+
+1. User decides to remove a person from a table.
+2. User enters the command in the correct format:  
+   `deletePersonFromTable n/John Doe tid/1`
+3. WeddingHero checks if the specified person exists and is assigned to the specified table.
+4. WeddingHero removes the person from the table.
+5. WeddingHero displays a confirmation message that the person has been successfully removed from the table.  
+   Use case ends.
+
+**Extensions:**
+
+3a. **Person Not Found**
+- 3a1. If the specified person does not exist, WeddingHero informs the user.
+- 3a2. User is prompted to re-enter a valid person name.
+- 3a3. Upon valid input, the process resumes at step 3.
+
+3b. **Table Not Found**
+- 3b1. If the specified table does not exist, WeddingHero informs the user.
+- 3b2. User is prompted to re-enter a valid table ID.
+- 3b3. Upon valid input, the process resumes at step 3.
+
+3c. **Person Not Assigned to Table**
+- 3c1. If the person is not assigned to the specified table, WeddingHero informs the user.
+- 3c2. User may choose to cancel or try another table ID.
+
+2a. **Invalid Input Format**
+- 2a1. If the input is missing required fields or incorrectly formatted, WeddingHero displays an error message showing the correct format.
+- 2a2. Upon receiving the correct input, the process resumes at step 3.
+
 
 ### Non-Functional Requirements
 
@@ -770,3 +851,4 @@ Removes a person from a table in the currently active wedding.
 ## **Appendix: Planned Enhancements**
 
 Team size: 5
+

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -12,7 +12,7 @@ pageNav: 3
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Acknowledgements**
-- The project is based on the AddressBook-Level2 project created by the SE-EDU initiative
+- The project is based on the AddressBook-Level3 project created by the SE-EDU initiative
 - Github CoPilot was used by Bhavina Sathish Kumar to write trivial test cases and the JavaDocs for some trivial methods
 
 
@@ -482,7 +482,7 @@ Use case ends.
 **MSS**
 
 1. User decides to add a new table.
-2. User enters the command eg. `addTable tid/4 8` with the desired table's ID and capacity.
+2. User enters the command eg. `addTable tid/4 c/8` with the desired table's ID and capacity.
 3. WeddingHero validates that the table ID is unique and that the capacity is a valid positive integer.
 4. WeddingHero adds the table to the current wedding selected by `setWedding`.
 5. WeddingHero displays a confirmation message indicating that the table has been successfully added.
@@ -759,8 +759,8 @@ Allows you to filter your list of persons by applying DIETARYRESTRICTION and/or 
 
 **Prerequisites:** You have created and set a wedding, with a person with `n/John Doe` added with the HALAL dietary restriction
 
-**Test case:** `filterPersons Halal`  
-**Expected Result:** You would get a filtered list with the HALAL tag, and John Doe would be reflected.
+**Test case:** `filterPersons r/Halal`  
+**Expected Result:** You would have a filtered list of persons with the HALAL tag, including John Doe.
 
 ---
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -353,8 +353,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. User wants to view the wedding overview.
-2. WeddingHero retrieves the overview details of the current active wedding, including the number of tables, guests
-   and list of guests.
+2. WeddingHero retrieves the overview details of the current active wedding, including the number of tables, guests and list of guests.
 3. WeddingHero displays the wedding overview information.
 4. Use case ends.
 
@@ -543,13 +542,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ## **Appendix: Instructions for manual testing**
 
 Given below are instructions to test the app manually.
-
-Set Wedding 
-
-CreateWedding 
-
-DeleteWedding 
-
 
 <box type="info" seamless>
 **Note:** These instructions only provide a starting point for testers to work on; testers are expected to do more *exploratory* testing.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -157,6 +157,25 @@ Classes used by multiple components are in the `seedu.address.commons` package.
 
 This section describes some noteworthy details on how certain features are implemented.
 
+### `addPersonToTable` Command
+
+The `addPersonToTable`  allows a user to assign a specific guest to a specific table within the currently active wedding.
+
+The implementation involves several validation steps:
+- Checking that the input format is correct
+- Checking that the specified person exists in the current guest list
+- Checking that the table exists
+- Ensuring the table has available capacity
+
+Once all conditions are met, the guest is assigned to the table and the system state is saved.
+
+The activity diagram below illustrates the control flow of this command
+
+<puml src="diagrams/AddPersonToTableActivityDiagram.puml" width="600" alt="Activity diagram for addPersonToTable command" />
+
+
+
+
 ### \[Proposed\] Undo/redo feature
 
 #### Proposed Implementation

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -390,7 +390,7 @@ Use case ends.
 
 ---
 
-### UC4: Add a guest
+### UC4: Add a Person
 
 **Preconditions:**
 - A wedding has been created.
@@ -398,12 +398,12 @@ Use case ends.
 
 **MSS**
 
-1. User decides to add a new guest.
-2. User to enters the guest details in the following correct format:
+1. User decides to add a new Person.
+2. User to enters the person details in the following correct format:
    `addPerson n/john Doe p/81231234 e/JohnDoe@gmail.com a/123 Kent Ridge d/None r/YES`
 3. WeddingHero validates the entered details.
-4. WeddingHero adds the guest to the current wedding's guest list.
-5. WeddingHero displays a confirmation message that the guest has been successfully added.
+4. WeddingHero adds the person to the current wedding's guest list.
+5. WeddingHero displays a confirmation message that the person has been successfully added.
    Use case ends.
 
 **Extensions:**
@@ -424,14 +424,14 @@ Use case ends.
 - 2c3. Once valid input is provided, the process resumes at step 3.
 
 3c. **Duplicate Person**
-- 3c1. If WeddingHero detects that a guest with the same identifier (e.g. same name) already exists,
+- 3c1. If WeddingHero detects that a person with the same identifier (e.g. same name) already exists,
     it notifies the user of the duplicate.
-- 3c2. WeddingHero prompts the user that guest has already been added.
+- 3c2. WeddingHero prompts the user that person has already been added.
 Use case ends.
 
 ---
 
-### UC5: Delete a guest
+### UC5: Delete a person
 
 **Preconditions:**
 - A wedding has been created.
@@ -441,20 +441,20 @@ Use case ends.
 
 1. User requests to view the current guest list.
 2. WeddingHero displays the list of guests.
-3. User selects a guest to delete by providing an identifier (guest name), e.g., `deletePerson n/John Doe`.
-4. WeddingHero searches for a guest matching the provided nam
-5. WeddingHero deletes the guest.
+3. User selects a person to delete by providing an identifier (person name), e.g., `deletePerson n/John Doe`.
+4. WeddingHero searches for a person matching the provided nam
+5. WeddingHero deletes the person.
    Use case ends.
 
 **Extensions:**
 
 3a. **Alternative Identifier: Phone Number**
-- 3a1. Instead of using the guest name, the user issues the delete command with a phone number identifier (e.g., `deleteGuest p/81231234`).
-- 3a2. WeddingHero searches for a guest matching the provided phone number.
+- 3a1. Instead of using the guest name, the user issues the delete command with a phone number identifier (e.g., `deletePerson p/81231234`).
+- 3a2. WeddingHero searches for a person matching the provided phone number.
 - 3a3. WeddingHero then proceeds to step 5 of the MSS.
 
 3b. **Missing Identifier Tag**
-- 3b1. The user issues the delete command without using the required identifier tag (e.g., `deleteGuest John Doe` without `n/` or `p/`).
+- 3b1. The user issues the delete command without using the required identifier tag (e.g., `deletePerson John Doe` without `n/` or `p/`).
 - 3b2. WeddingHero detects the missing tag and displays an error message instructing the user to use the correct identifier format.
 - 3b3. WeddingHero prompts the user to re-enter the command with either of the proper tags.
 - 3b4. If the user re-enters the command with a valid identifier, the process resumes at step 4.
@@ -631,6 +631,7 @@ Use case ends.
 # Glossary
 
 - **Person:** An individual invited to attend the wedding.
+- **Guest:** A Person invited to attend the wedding.
 - **Table:** A designated seating area at the wedding venue, typically used to group guests together.
 - **Dietary Restriction:** A limitation or specific requirement regarding food consumption, often due to allergies, health conditions, or personal preferences.
 - **RSVP Status:** The response provided by an invited guest indicating whether they will attend the event.
@@ -668,7 +669,8 @@ Creates a new wedding where Persons and Tables can be added after it has been se
 **Test case:** `createWedding n/John & Jane Wedding`  
 **Expected Result:** New Wedding is added to the list. A message that a new wedding has been created is shown.
 
-**Test case:** `createWedding n/John & Jane Wedding`  
+**Test case:** `createWedding n/John & Jane Wedding`, then do the command`createWedding n/John & Jane Wedding` again
+
 **Expected Result:** A message that a wedding already exists with the name is shown.
 
 **Incorrect Test Commands:**

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -286,7 +286,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | ***      | wedding planner                                         | decide how many guests should be seated at one table                                           | customise it to my clients’ needs                                                                              |
 | ***      | wedding planner                                         | view the entire table list quickly                                                             | quickly see the list of tables and their capacities                                                           |
 | **       | organised wedding planner                               | filter guests based on their dietary restrictions and RSVP status                              | view guests based on a specific category                                                                       |
-| **       | wedding planner                                         | leave notes and comments on tasks                                                              | my team stays aligned without needing endless back-and-forth messages                                         |
 | *        | forgetful wedding planner                               | mark the status of the vendor list                                                             | keep track of whether a vendor has confirmed                                                                   |
 | *        | detailed wedding planner                                | see a list of upcoming tasks that are most urgent                                              | pay attention to them first                                                                                    |
 | *        | wedding planner                                         | create a library of preferred vendors and pricing details                                      | easily recommend the best options to my clients                                                                |
@@ -461,7 +460,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. User decides to add a new table.
-2. User enters the command `addTable tableID/4 8` with the desired table's ID and capacity.
+2. User enters the command eg. `addTable tid/4 8` with the desired table's ID and capacity.
 3. WeddingHero validates that the table ID is unique and that the capacity is a valid positive integer.
 4. WeddingHero adds the table to the current wedding selected by `setWedding`.
 5. WeddingHero displays a confirmation message indicating that the table has been successfully added.
@@ -495,7 +494,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. User decides to delete an existing table.
-2. User enters the command `deleteTable tableID/3` with the desired table's ID.
+2. User enters the command eg. `deleteTable tid/3` with the desired table's ID.
 3. WeddingHero validates that the table ID is provided.
 4. WeddingHero searches for the table matching the provided ID.
 5. If a matching table is found, WeddingHero prompts the user to confirm the deletion.
@@ -559,16 +558,214 @@ DeleteWedding
 ### Launch and shutdown
 
 1. Initial launch
-   1. Download the jar file and copy it into an empty folder.
-   2. Double-click the jar file.
+   1a. Download the jar file and copy it into an empty folder.
+   1b. Double-click the jar file.
       Expected: Shows the GUI with a set of sample contacts. The window size may not be optimum.
 
 2. Saving window preferences
-   1. Resize the window to an optimum size. Move the window to a different location. Close the window.
-   2. Re-launch the app by double-clicking the jar file.
+   2a.Resize the window to an optimum size. Move the window to a different location. Close the window.
+   2b.Re-launch the app by double-clicking the jar file.
       Expected: The most recent window size and location is retained.
 
-3. _{ more test cases … }_
+
+### Creating a New Wedding
+Creates a new wedding where Persons and Tables can be added after it has been set.
+
+**Prerequisites:** None
+
+**Test case:** `createWedding n/John & Jane Wedding`  
+**Expected Result:** New Wedding is added to the list. A message that a new wedding has been created is shown.
+
+**Test case:** `createWedding n/John & Jane Wedding`  
+**Expected Result:** A message that a wedding already exists with the name is shown.
+
+**Incorrect Test Commands:**
+- `createWedding John`
+- `createWedding`  
+  **Expected Result:** Error details of incorrect format and right usage are shown in the status message.
+
+---
+
+### Set Wedding
+Sets a wedding that has been created.
+
+**Prerequisites:** Wedding John & Jane has been created
+
+**Test case:** `setWedding n/John & Jane`  
+**Expected Result:** A message would be shown to indicate that the wedding has been set, and this would be reflected in the GUI.
+
+**Test case:** `setWedding n/Aikeen & Dueet`  
+**Expected Result:** An error message would be shown to indicate there is no such wedding.
+
+**Incorrect Test Commands:**
+- `setWedding John`
+- `setWedding`
+
+---
+
+### Wedding Overview
+Shows an overview of the current wedding including the number of people invited, the number of tables, and the guest names.
+
+**Prerequisites:** A wedding has been set
+
+**Test case:** `weddingOverview`  
+**Expected Result:** A message showing the number of people attending, the number of tables present and the guest names would be shown.
+
+**Incorrect Test Command:** `weddingOverview n/`  
+**Expected Result:** An error message showing that it is an incorrect command is shown.
+
+---
+
+### Delete Wedding
+Deletes the Wedding and removes all instances of the People and the Tables in the wedding.
+
+**Prerequisites:** A Wedding named John & Jane has been created
+
+**Test case:** `deleteWedding n/John & Jane`  
+**Expected Result:** The wedding of John & Jane is deleted. A message is shown that the wedding has been deleted.
+
+**Test case:** `deleteWedding n/Aikeen & Dueet`  
+**Expected Result:** No such error message is shown.
+
+**Incorrect Test Command:** `deleteWedding`  
+**Expected Result:** A message showing the correct error message is shown.
+
+---
+
+### Adding a Person
+Allows you to add people to the currently setWedding.
+
+**Prerequisites:** A Wedding named John & Jane has been created, and the wedding has been set
+
+**Test case:** `addPerson n/John Doe p/12345678 e/johndoe@example.com a/123 Street d/NONE r/YES`  
+**Expected Result:** The person John Does is added to the current wedding, and is reflected in the GUI.
+
+**Incorrect Test Command:** `addPerson n/John Doe p/12345678 e/johndoe@example.com a/123 Street d/NONE r/WHAT_HELP`  
+**Expected Result:** An error message is shown.
+
+---
+
+### Deleting a Person
+Deletes a person from the currently active wedding's person list, using their displayed index number.
+
+**Prerequisites:** A Wedding named John & Jane has been created, and the wedding has been set. John Doe has been added, and is the first person shown in the list
+
+**Test case:** `deletePerson 1`  
+**Expected Result:** The first person on the list, eg. John Doe would be deleted.
+
+**Incorrect Test Commands:**
+- `deletePerson -8`
+- `deletePerson a`  
+  **Expected Result:** An error message showing the correct input format is given.
+
+---
+
+### Filtering Persons
+Allows you to filter your list of persons by applying DIETARYRESTRICTION and/or RSVP status filters.
+
+**Prerequisites:** You have created and set a wedding, with a person with `n/John Doe` added with the HALAL dietary restriction
+
+**Test case:** `filterPersons Halal`  
+**Expected Result:** You would get a filtered list with the HALAL tag, and John Doe would be reflected.
+
+---
+
+### Adding a Table
+Adds a table with the specified table ID and capacity to the current wedding.
+
+**Prerequisites:** A Wedding has been created and set
+
+**Test case:** `addTable tid/12 c/8`  
+**Expected Result:** Will add a table, and would be reflected in the GUI.
+
+**Test case:** `addTable tid/120 c/8`  
+**Expected Result:** Would show that the ID is above the set limit.
+
+**Incorrect Test Commands:**
+- `addTable 120 8`
+- `addTable tid/ss c/3`  
+  **Expected Result:** An error message showing that it is an incorrect error message is shown.
+
+---
+
+### Deleting a Table
+Deletes a table by its table ID.
+
+**Prerequisites:** A Wedding has been created and set. Only a table with table id 1 has been added.
+
+**Test case:** `deleteTable tid/1`  
+**Expected Result:** The table with tableID one has been deleted and it would be removed from the list.
+
+**Test case:** `deleteTable tid/199`  
+**Expected Result:** An error message would be shown that the table does not exist.
+
+**Incorrect Test Commands:**
+- `deleteTable 2`
+- `deleteTable`
+- `deleteTable 3a`
+
+---
+
+### Listing Tables
+Lists all tables currently added to the wedding layout.
+
+**Prerequisites:** A Wedding has been created and set. Only a table with table id 1 has been added.
+
+**Test case:** `getTables`  
+**Expected Result:** The list of current tables is shown.
+
+**Incorrect Test Command:** `getTables a`  
+**Expected Result:** Would give an error message regarding the input.
+
+---
+
+### Finding Tables
+Finds a table by its ID.
+
+**Test case:** `findTable tid/12`  
+**Expected Result:** Displays the table with the id 12.
+
+**Incorrect Test Commands:**
+- `findTables 1`
+- `findTables a`  
+  **Expected Result:** Would give an error message regarding the input.
+
+---
+
+### Assigning a Person to a Table
+Assigns a Person to a specified Table within the currently active wedding.
+
+**Prerequisites:** A Wedding has been created and set. Only a table with table id 1 has been added. A person with the name John Doe has been added.
+
+**Test case:** `addPersonToTable n/John Doe tid/1`  
+**Expected Result:** The table 5 has a person named John Doe, and the person has the corresponding ID.
+
+**Test case:** `addPersonToTable n/John x Doe tid/1`  
+**Expected Result:** Won’t add the person to the table, as the person does not exist.
+
+**Test case:** `addPersonToTable n/John Doe tid/3`  
+**Expected Result:** Won’t add the person to the table, as the table does not exist.
+
+**Incorrect Test Command:** `addPersonToTable John Doe t1`  
+**Expected Result:** Would give an error message regarding the input.
+
+---
+
+### Deleting a Person from a Table
+Removes a person from a table in the currently active wedding.
+
+**Prerequisites:** A Wedding has been created and set. Only a table with table id 1 has been added. A person with the name John Doe has been added and assigned to the table.
+
+**Test case:** `deletePersonFromTable n/John Doe tid/5`  
+**Expected Result:** The person is deleted from the table.
+
+**Test case:** `deletePersonFromTable n/John Doee tid/5`  
+**Expected Result:** A message that the person does not exist would be shown.
+
+**Test case:** `deletePersonFromTable n/John Doe tid/3`  
+**Expected Result:** A message that the table does not exist would be shown.
+
+---
 
 ### Saving data
 
@@ -576,3 +773,8 @@ DeleteWedding
    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
 
 2. _{ more test cases … }_
+
+
+## **Appendix: Planned Enhancements**
+
+Team size: 5

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -545,6 +545,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 Given below are instructions to test the app manually.
 
+Set Wedding 
+
+CreateWedding 
+
+DeleteWedding 
+
+
 <box type="info" seamless>
 **Note:** These instructions only provide a starting point for testers to work on; testers are expected to do more *exploratory* testing.
 </box>

--- a/docs/diagrams/AddPersonToTableActivityDiagram.puml
+++ b/docs/diagrams/AddPersonToTableActivityDiagram.puml
@@ -1,0 +1,31 @@
+@startuml
+start
+
+:User enters command
+"addPersonToTable n/John Doe tid/1";
+
+:Parse command;
+
+if (Command format valid?) then (yes)
+  :Extract name and table ID;
+  if (Person exists?) then (yes)
+    if (Table exists?) then (yes)
+      if (Table has capacity?) then (yes)
+        :Assign person to table;
+        :Save to storage;
+        :Show success message;
+      else (no)
+        :Shows the  "Table is full" error;
+      endif
+    else (no)
+      :Shows the "Table not found" error;
+    endif
+  else (no)
+    :Shows the "Person not found" error;
+  endif
+else (no)
+  :Shows that the Format is wrong;
+endif
+
+stop
+@enduml

--- a/docs/team/bhavinaa.md
+++ b/docs/team/bhavinaa.md
@@ -1,0 +1,46 @@
+---
+  layout: default.md
+  title: "Bhavinaa's Project Portfolio Page"
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **New Feature**: Added the ability to undo/redo previous commands.
+    * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
+    * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
+    * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
+    * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
+
+* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Project management**:
+    * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub
+
+* **Enhancements to existing features**:
+    * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+    * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+    * User Guide:
+        * Added documentation for the features `delete` and `find` [\#72]()
+        * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+    * Developer Guide:
+        * Added implementation details of the `delete` feature.
+
+* **Community**:
+    * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+    * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+    * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+    * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Tools**:
+    * Integrated a third party library (Natty) to the project ([\#42]())
+    * Integrated a new Github plugin (CircleCI) to the team repo
+
+* _{you can add/remove categories in the list above}_

--- a/src/main/java/seedu/address/logic/commands/DeleteWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWeddingCommand.java
@@ -14,7 +14,7 @@ public class DeleteWeddingCommand extends Command {
     public static final String COMMAND_WORD = "deleteWedding";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes the current wedding.\n"
         + "Parameters: n/NAME"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " Jon's Wedding";
+            + " Example: " + COMMAND_WORD + " " + PREFIX_NAME + " Jon's Wedding";
 
     public static final String MESSAGE_SUCCESS = "Wedding deleted: %1$s";
     public static final String MESSAGE_NO_WEDDING = "No wedding with the name '%s' exists.";


### PR DESCRIPTION
Use Case Table Changes
- Replaced the second column with USE CASE2 (third column of original table).
- Removed the use case: “Team is aligned” – not relevant to a single-user system.
- Removed the vendor use case in the final version.
- Removed the use case: "Send messages to guests, vendors, photographers" — may violate the single-user design principle.
- Removed the use case: "Share to-do list" — likely violates the single-user constraint.

Use Case List Modifications
- Renumbered use cases consistently using format UC1, UC2, … for easier reference.
- formatted each use case to end on a new line for better readability.
- Improved the ordering of extensions in each use case to reflect a logical flow and better structure.

Added the Appendix with the test cases for the manual testing


changed the syntax error in the deleteTable command
added the PPP, but did not change anything in it
